### PR TITLE
Fix multiple instances of the bot being created

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,13 +21,10 @@ async def on_autopost_success():
 
 
 @client.event
-async def on_ready() -> None:
+async def setup_hook() -> None:
     logger.info("file: main.py ~ on_ready ~ %s",
                 datetime.utcnow().strftime("%d/%m/%Y %H:%M:%S"))
-    logger.info("file: main.py ~ logged in as a bot %s", client.user)
-    server_ids = [guild.id for guild in client.guilds]
-    logger.info('file: main.py ~ server IDs: %s ~ total count: %s',
-                server_ids, len(server_ids))
+    logger.info("file: main.py ~ on_ready ~ logged in as a bot %s", client.user)
 
     if os.environ["PRODUCTION"] == "True":
         dbl_token = os.environ["TOPGG_TOKEN"]
@@ -36,15 +33,15 @@ async def on_ready() -> None:
 
     try:
         synced = await client.tree.sync()
-        logger.info("file: main.py ~ synced %s commands", len(synced))
+        logger.info(
+            "file: main.py ~ on_ready ~ synced %s commands", len(synced))
 
-        if os.environ["UPDATE_STATS_ON_START"] == "True":
-            daily_reset = os.environ["DAILY_RESET"] == "True"
-            weekly_reset = os.environ["WEEKLY_RESET"] == "True"
+        # TODO: re-enable force update
+        update_stats_on_start = os.environ["UPDATE_STATS_ON_START"] == "True"
+        daily_reset = os.environ["DAILY_RESET"] == "True"
+        weekly_reset = os.environ["WEEKLY_RESET"] == "True"
 
-            await send_daily_question_and_update_stats(True, daily_reset, weekly_reset)
-        else:
-            await send_daily_question_and_update_stats()
+        send_daily_question_and_update_stats.start()
 
     except Exception as e:
         logger.exception("file: main.py ~ on_ready ~ exception: %s", e)


### PR DESCRIPTION
The issue of multiple instances of the bot being created was due to the fact that the shard id becomes invalidated and so on_ready is rerun. Therefore, to fix this, on_ready had to be replaced with setup_hook as this coroutine only runs once. Setup_hook cannot contain an infinite while loop, therefore send_daily_question_and_update_stats scheduled waiting system had to be replaced with discord.ext.tasks.loop. This did remove the force update functionality, which needs to be implemented back again in the future.