### PR TITLE
Defer image converter to prevent interaction failed message

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -40,12 +40,13 @@ class Stats(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
+        await interaction.response.defer(ephemeral=True)
         embed, file = await stats_embed(user.leetcode_username)
 
         if file is None:
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
         else:
-            await interaction.response.send_message(embed=embed, file=file, ephemeral=not display_publicly)
+            await interaction.followup.send(embed=embed, file=file, ephemeral=not display_publicly)
 
 
 async def setup(client: commands.Bot):

--- a/embeds/stats_embeds.py
+++ b/embeds/stats_embeds.py
@@ -17,20 +17,23 @@ def stats_embed(leetcode_username: str) -> Tuple[discord.Embed, discord.File | N
     embed.set_footer(
         text="Credit to github.com/JacobLinCool/LeetCode-Stats-Card")
 
-    url = f"https://leetcard.jacoblin.cool/{leetcode_username}?theme=dark&font=Overpass%20Mono&animation=false&width=500&ext=activity"
+    width = 500
+    height = 400
+
+    url = f"https://leetcard.jacoblin.cool/{leetcode_username}?theme=dark&font=Overpass%20Mono&animation=false&width={width}&height={height}&ext=activity"
 
     # Making sure the website is reachable before running hti.screenshot()
     # as the method will stall if url isn't reachable.
     try:
-        get = requests.get(url)
+        response = requests.get(url)
 
-        if get.status_code != 200:
+        if response.status_code != 200:
             return error_embed(), None
 
     except requests.exceptions.RequestException as e:
         return error_embed(), None
 
-    paths = hti.screenshot(url=url, size=(500, 400))
+    paths = hti.screenshot(url=url, size=(width, height))
 
     with open(paths[0], "rb") as f:
         # read the file contents


### PR DESCRIPTION
On slower bot host servers, an "interaction has failed" message will be returned due to the fact that the image converter takes a significant time to compute and there was no interaction deferral.