### PR TITLE
Defer most commands until a followup is ready to be sent

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -30,12 +30,14 @@ class Channels(commands.GroupCog, name="settings"):
             embed = invalid_timezone_embed()
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
+        
+        await interaction.response.defer(ephemeral=True)
 
         server_id = interaction.guild.id
         await Server.find_one(Server.id == server_id).update(Set({Server.timezone: timezone}))
 
         embed = timezone_updated_embed()
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        await interaction.followup.send(embed=embed, ephemeral=True)
 
 
 async def setup(client: commands.Bot):

--- a/cogs/leaderboards.py
+++ b/cogs/leaderboards.py
@@ -22,7 +22,7 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
             embed = error_embed()
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
-        
+
         await interaction.response.defer()
 
         await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "alltime", page)
@@ -37,7 +37,7 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
             embed = error_embed()
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
-        
+
         await interaction.response.defer()
 
         await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "weekly", page)

--- a/cogs/leaderboards.py
+++ b/cogs/leaderboards.py
@@ -22,8 +22,10 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
             embed = error_embed()
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
+        
+        await interaction.response.defer()
 
-        await display_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "alltime", page)
+        await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "alltime", page)
 
     @discord.app_commands.command(name="weekly", description="View the Weekly leaderboard")
     @ensure_server_document
@@ -35,8 +37,10 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
             embed = error_embed()
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
+        
+        await interaction.response.defer()
 
-        await display_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "weekly", page)
+        await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "weekly", page)
 
     @discord.app_commands.command(name="daily", description="View the Daily leaderboard")
     @ensure_server_document
@@ -49,7 +53,9 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
-        await display_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "daily", page)
+        await interaction.response.defer()
+
+        await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "daily", page)
 
 
 async def setup(client: commands.Bot):

--- a/cogs/questions.py
+++ b/cogs/questions.py
@@ -9,7 +9,7 @@ from embeds.misc_embeds import error_embed
 from embeds.questions_embeds import (daily_question_embed, question_embed,
                                      question_has_no_rating_embed,
                                      question_rating_embed)
-from utils.ratings import get_rating_data
+from utils.ratings import get_rating_data_to_thread
 from utils.middleware import track_analytics
 
 
@@ -35,7 +35,7 @@ class Questions(commands.Cog):
 
         await interaction.response.defer()
 
-        rating_data = await get_rating_data(question_id_or_title)
+        rating_data = await get_rating_data_to_thread(question_id_or_title)
 
         rating_text = "Doesn't exist"
 
@@ -104,7 +104,7 @@ class Questions(commands.Cog):
 
         link = f"https://leetcode.com/problems/{question_title_slug}/"
 
-        rating_data = await get_rating_data(question_title)
+        rating_data = await get_rating_data_to_thread(question_title)
 
         rating_text = "Doesn't exist"
         if rating_data is not None:

--- a/cogs/questions.py
+++ b/cogs/questions.py
@@ -22,16 +22,20 @@ class Questions(commands.Cog):
     async def daily(self, interaction: discord.Interaction) -> None:
         logger.info("file: cogs/questions.py ~ get_daily ~ run")
 
-        embed = daily_question_embed()
+        await interaction.response.defer()
 
-        await interaction.response.send_message(embed=embed)
+        embed = await daily_question_embed()
+
+        await interaction.followup.send(embed=embed)
 
     @discord.app_commands.command(name="rating", description="Returns the Zerotrac rating of the problem")
     @track_analytics
     async def rating(self, interaction: discord.Interaction, question_id_or_title: str) -> None:
         logger.info("file: cogs/questions.py ~ get_rating ~ run")
 
-        rating_data = get_rating_data(question_id_or_title)
+        await interaction.response.defer()
+
+        rating_data = await get_rating_data(question_id_or_title)
 
         rating_text = "Doesn't exist"
 
@@ -41,11 +45,11 @@ class Questions(commands.Cog):
             embed = question_rating_embed(
                 rating_data["question_name"], rating_text)
 
-            await interaction.response.send_message(embed=embed)
+            await interaction.followup.send(embed=embed)
             return
 
         embed = question_has_no_rating_embed()
-        await interaction.response.send_message(embed=embed)
+        await interaction.followup.send(embed=embed)
 
     @discord.app_commands.command(
         name="question",
@@ -57,6 +61,8 @@ class Questions(commands.Cog):
 
         difficulty = difficulty.lower()
 
+        await interaction.response.defer()
+
         try:
             response = requests.get(
                 "https://leetcode.com/api/problems/all/", timeout=10)
@@ -67,7 +73,7 @@ class Questions(commands.Cog):
 
             embed = error_embed(
                 f"An error occurred while trying to get the question from LeetCode. LeetCode may be down.")
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             return
 
         if response.status_code != 200:
@@ -76,7 +82,7 @@ class Questions(commands.Cog):
 
             embed = error_embed(
                 f"An error occurred while trying to get the question from LeetCode. LeetCode may be down.")
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             return
 
         data = response.json()
@@ -98,14 +104,14 @@ class Questions(commands.Cog):
 
         link = f"https://leetcode.com/problems/{question_title_slug}/"
 
-        rating_data = get_rating_data(question_title)
+        rating_data = await get_rating_data(question_title)
 
         rating_text = "Doesn't exist"
         if rating_data is not None:
             rating_text = f"||{int(rating_data['rating'])}||"
 
         embed = question_embed(difficulty, question_title, rating_text, link)
-        await interaction.response.send_message(embed=embed)
+        await interaction.followup.send(embed=embed)
 
 
 async def setup(client: commands.Bot):

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 
 from bot_globals import logger
+from embeds.misc_embeds import error_embed
 from embeds.stats_embeds import stats_embed, account_hidden_embed
 from embeds.users_embeds import account_not_found_embed
 from models.user_model import User
@@ -17,7 +18,11 @@ class Stats(commands.Cog):
     async def stats(self, interaction: discord.Interaction, user: discord.Member | None = None, display_publicly: bool = True) -> None:
         logger.info('file: cogs/stats.py ~ stats ~ run')
 
+        await interaction.response.defer(ephemeral=not display_publicly)
+
         if not interaction.guild:
+            embed = error_embed()
+            await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
         if user:
@@ -29,7 +34,7 @@ class Stats(commands.Cog):
 
         if not user:
             embed = account_not_found_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         display_information = next(
@@ -37,10 +42,8 @@ class Stats(commands.Cog):
 
         if user.id != interaction.user.id and not display_information.url:
             embed = account_hidden_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
-
-        await interaction.response.defer(ephemeral=not display_publicly)
 
         # Needed because if user already has connected their account to the bot
         # but hasn't connected their account to the corresponding server,

--- a/cogs/users.py
+++ b/cogs/users.py
@@ -39,7 +39,11 @@ class Users(commands.Cog):
             'file: cogs/users.py ~ add ~ run ~ leetcode_username: %s, include_url: %s', leetcode_username, include_url)
 
         if not interaction.guild:
+            embed = error_embed()
+            await interaction.response.send_message(embed=embed, ephemeral=True)
             return
+
+        await interaction.response.defer(ephemeral=True)
 
         server_id = interaction.guild.id
         user_id = interaction.user.id
@@ -48,7 +52,7 @@ class Users(commands.Cog):
 
         if not server_exists:
             embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         display_information = DisplayInformation(
@@ -65,7 +69,7 @@ class Users(commands.Cog):
 
                 # User has already been added in the server
                 embed = user_already_added_in_server_embed()
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed)
 
             else:
                 logger.info(
@@ -81,7 +85,7 @@ class Users(commands.Cog):
                 await server.save()
 
                 embed = synced_existing_user_embed()
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed)
 
         else:
             # Generate a random string for account linking
@@ -90,7 +94,7 @@ class Users(commands.Cog):
 
             embed = connect_account_instructions_embed(
                 generated_string, leetcode_username)
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
 
             profile_name = None
             check_interval = 5  # seconds
@@ -157,16 +161,20 @@ class Users(commands.Cog):
             'file: cogs/users.py ~ update ~ run ~ include_url: %s', include_url)
 
         if not interaction.guild:
+            embed = error_embed()
+            await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
         server_id = interaction.guild.id
         user_id = interaction.user.id
 
+        await interaction.response.defer(ephemeral=True)
+
         server_exists = await Server.find_one(Server.id == server_id).project(IdProjection)
 
         if not server_exists:
             embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         user = await User.find_one(User.id == user_id)
@@ -175,14 +183,14 @@ class Users(commands.Cog):
             await User.find_one(User.id == user.id, User.display_information.server_id == server_id).update(Set({"display_information.$.url": include_url}))
             embed = profile_details_updated_embed()
 
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         logger.info(
             'file: cogs/users.py ~ remove ~ profile not found in this server ~ user_id: %s', user_id)
 
         embed = account_not_found_embed()
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        await interaction.followup.send(embed=embed)
 
     @discord.app_commands.command(name="remove", description="Remove your profile from this server's leaderboard")
     @ensure_server_document
@@ -199,11 +207,13 @@ class Users(commands.Cog):
         server_id = interaction.guild.id
         user_id = interaction.user.id
 
+        await interaction.response.defer(ephemeral=True)
+
         server_exists = await Server.find_one(Server.id == server_id).project(IdProjection)
 
         if not server_exists:
             embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         logger.info(
@@ -225,14 +235,14 @@ class Users(commands.Cog):
                     'file: cogs/users.py ~ remove ~ profile removed - references removed from User and Server documents ~ user_id: %s', user_id)
 
                 embed = account_removed_embed()
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed)
                 return
 
         logger.info(
             'file: cogs/users.py ~ remove ~ profile not found in this server ~ user_id: %s', user_id)
 
         embed = account_not_found_embed()
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        await interaction.followup.send(embed=embed)
 
 
 async def setup(client: commands.Bot):

--- a/embeds/questions_embeds.py
+++ b/embeds/questions_embeds.py
@@ -4,8 +4,10 @@ import requests
 from bot_globals import logger
 from embeds.misc_embeds import error_embed
 from utils.ratings import get_rating_data
+from utils.run_blocking import to_thread
 
 
+@to_thread
 def daily_question_embed() -> discord.Embed:
     logger.info(
         "file: embeds/questions_embeds.py ~ daily_question_embed ~ run")
@@ -57,7 +59,7 @@ def daily_question_embed() -> discord.Embed:
 
     link = f"https://leetcode.com{response_data['data']['challenge']['link']}"
 
-    rating_data = get_rating_data(question_title)
+    rating_data = await get_rating_data(question_title)
 
     rating_text = "Doesn't exist"
     if rating_data is not None:

--- a/embeds/questions_embeds.py
+++ b/embeds/questions_embeds.py
@@ -59,7 +59,7 @@ def daily_question_embed() -> discord.Embed:
 
     link = f"https://leetcode.com{response_data['data']['challenge']['link']}"
 
-    rating_data = await get_rating_data(question_title)
+    rating_data = get_rating_data(question_title)
 
     rating_text = "Doesn't exist"
     if rating_data is not None:

--- a/utils/message_scheduler.py
+++ b/utils/message_scheduler.py
@@ -67,7 +67,7 @@ async def send_daily_question_and_update_stats() -> None:
             await send_leaderboard_winners(server, "last_week")
 
     if daily_reset:
-        embed = daily_question_embed()
+        embed = await daily_question_embed()
 
         async for server in Server.all(fetch_links=True):
             await send_daily_question(server, embed)

--- a/utils/ratings.py
+++ b/utils/ratings.py
@@ -4,6 +4,7 @@ from bot_globals import RATINGS
 from utils.run_blocking import to_thread
 
 
+@to_thread
 def get_rating_data(title: str) -> Dict | None:
     if title.isnumeric():
         question_id = int(title)

--- a/utils/ratings.py
+++ b/utils/ratings.py
@@ -4,7 +4,6 @@ from bot_globals import RATINGS
 from utils.run_blocking import to_thread
 
 
-@to_thread
 def get_rating_data(title: str) -> Dict | None:
     if title.isnumeric():
         question_id = int(title)
@@ -22,6 +21,11 @@ def get_rating_data(title: str) -> Dict | None:
             "rating": RATINGS[title.lower()]["rating"]
         }
         return rating_data
+
+
+@to_thread
+def get_rating_data_to_thread(title: str) -> Dict | None:
+    return get_rating_data(title)
 
 
 @to_thread


### PR DESCRIPTION
- Not deferring command messages would occasionally lead to an "interaction has failed" error being displayed to the user, and no reply to be sent.