### PR TITLE
Update roles at midday UTC rather than midnight UTC

### DIFF
--- a/utils/message_scheduler.py
+++ b/utils/message_scheduler.py
@@ -75,7 +75,7 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
             await update_rankings(server, now, "weekly")
             await send_leaderboard_winners(server, "last_week")
 
-        if daily_reset:
+        if midday:
             await update_roles(server)
 
     if daily_reset:

--- a/utils/roles.py
+++ b/utils/roles.py
@@ -140,9 +140,6 @@ async def give_streak_role(user: discord.User, guild_id: int, streak: int) -> No
         await discord_user.add_roles(role_to_assign)
         logger.info(
             "file: utils/roles.py ~ give_streak_role ~ assigned %s role to %s", role_to_assign.name, discord_user.display_name)
-    else:
-        logger.warning(
-            "file: utils/roles.py ~ give_streak_role ~ no suitable streak role found.")
 
 
 async def give_milestone_role(user: discord.User, guild_id: int, total_solved: int) -> None:
@@ -177,6 +174,3 @@ async def give_milestone_role(user: discord.User, guild_id: int, total_solved: i
         await discord_user.add_roles(role_to_assign)
         logger.info("file: utils/roles.py ~ give_milestone_role ~ assigned %s role to %s", role_to_assign.name,
                     discord_user.display_name)
-    else:
-        logger.warning(
-            "file: utils/roles.py ~ give_milestone_role ~ no suitable milestone role found.")


### PR DESCRIPTION
Updating roles takes has been found to take a considerable amount of time to process. Therefore, an investigation will be needed to fix this inefficiency.

For the moment, updating the roles at a less important time of midday rather than midnight (daily_reset) will make the daily_reset notifications to be sent at the appropriate time without a delay.