### PR TITLE
Delete user and server data if unneeded

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -30,7 +30,7 @@ class Channels(commands.GroupCog, name="settings"):
             embed = invalid_timezone_embed()
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
-        
+
         await interaction.response.defer(ephemeral=True)
 
         server_id = interaction.guild.id

--- a/embeds/users_embeds.py
+++ b/embeds/users_embeds.py
@@ -60,6 +60,13 @@ def account_removed_embed() -> discord.Embed:
     return embed
 
 
+def account_permanently_deleted_embed() -> discord.Embed:
+    embed = discord.Embed(title="Your account has been permanently deleted",
+                          color=discord.Color.green())
+
+    return embed
+
+
 def account_not_found_embed() -> discord.Embed:
     embed = discord.Embed(
         title="Account not found",

--- a/utils/message_scheduler.py
+++ b/utils/message_scheduler.py
@@ -1,6 +1,7 @@
 from datetime import datetime, time
 
 import discord
+from beanie.odm.operators.update.array import Pull
 from discord.ext import tasks
 
 from bot_globals import client, logger
@@ -9,8 +10,8 @@ from models.analytics_model import Analytics, AnalyticsHistory
 from models.server_model import Server
 from models.user_model import User
 from utils.leaderboards import send_leaderboard_winners
-from utils.stats import update_rankings, update_stats
 from utils.roles import update_roles
+from utils.stats import update_rankings, update_stats
 
 
 async def send_daily_question(server: Server, embed: discord.Embed) -> None:
@@ -56,8 +57,9 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
     daily_reset = (now.hour == 0 and now.minute == 0) or force_daily_reset
     weekly_reset = (now.weekday() == 0 and now.hour ==
                     0 and now.minute == 0) or force_weekly_reset
-
     midday = (now.hour == 12 and now.minute == 0)
+    remove_unneeded_data = (now.day == 1 and now.hour ==
+                            12 and now.minute == 0)
 
     if force_update_stats:
         async for user in User.all():
@@ -99,6 +101,44 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
         analytics.command_count_today = 0
 
         await analytics.save()
+
+    # Data removal process
+    if remove_unneeded_data:
+        async for server in Server.all():
+            # So that we can access user.id
+            await server.fetch_all_links()
+
+            guild = client.get_guild(server.id)
+
+            # Delete server document if the bot isn't in the server anymore
+            if not guild or guild not in client.guilds:
+                await server.delete()
+
+                logger.info(
+                    "file: utils/message_scheduler.py ~ send_daily_question_and_update_stats ~ server document deleted ~ id: %s", server.id)
+
+            for user in server.users:
+                # unlink user if server was deleted or if bot not in the server anymore
+                unlink_user = not guild or not guild.get_member(
+                    user.id)
+
+                # Unlink user from server if they're not in the server anymore
+                if unlink_user:
+                    await User.find_one(User.id == user.id).update(Pull({User.display_information: {"server_id": server.id}}))
+                    await Server.find_one(Server.id == server.id).update(Pull({Server.users: {"$id": user.id}}))
+
+                    logger.info(
+                        "file: utils/message_scheduler.py ~ send_daily_question_and_update_stats ~ user unlinked from server ~ user_id: %s, server_id: %s", user.id, server.id)
+
+        async for user in User.all():
+            # Delete user document if they're not in any server with the bot in it
+            if len(user.display_information) == 0:
+                await User.find_one(User.id == user.id).delete()
+
+                logger.info(
+                    "file: utils/message_scheduler.py ~ send_daily_question_and_update_stats ~ user document deleted ~ id: %s", user.id)
+
+                continue
 
     logger.info(
         "file: utils/message_scheduler.py ~ send_daily_question_and_update_stats ~ ended")


### PR DESCRIPTION
Due to the discord verification process requiring us to improve our data removal processes, I have implemented the following processes:
- A user can run the /remove permanently_delete=True command which will delete all their data from the database.
- At the beginning of each month, if the users are not connected to the bot in at least one server, all their data is automatically deleted from the database.
- At the beginning of each month, if a server has been deleted or the bot has been kicked from the server, all the server's data is automatically deleted from the database.