### PR TITLE
Replace double new lines with a single new line after markdown conversion

### DIFF
--- a/utils/questions.py
+++ b/utils/questions.py
@@ -245,14 +245,18 @@ def html_to_markdown(html):
         # Replace image tag with the url src of that image
         (r'<img.*?src="(.*?)".*?>', r'\1'),
         (r'<style.*?>.*?</style>', r''),
-        (r'\r\n', r''),
-        (r'\n', r''),
+        (r'&nbsp;', r' ')
     ]
 
     for pattern, replacement in subsitutions:
         html = re.sub(pattern, replacement, html, flags=re.DOTALL)
 
-    return markdownify.markdownify(html, heading_style="ATX")
+    markdown = markdownify.markdownify(html, heading_style="ATX")
+
+    # Remove unnecessary extra lines
+    markdown = re.sub(r'\n\n', '\n', markdown)
+
+    return markdown
 
 
 def get_problems_solved_and_rank(leetcode_username: str) -> dict[str, Any] | None:


### PR DESCRIPTION
There were issues with code blocks requiring newlines to be included, but the regex would remove all newlines. So now, only double new lines will be replaced with single new lines after the markdown conversion to remove extra empty lines outside code blocks.