### PR TITLE
Wrap all commands with created defer interaction decorator

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -5,10 +5,9 @@ from discord.ext import commands
 
 from bot_globals import logger
 from embeds.admin_embeds import invalid_timezone_embed, timezone_updated_embed
-from embeds.misc_embeds import error_embed
 from models.server_model import Server
-from utils.middleware import (admins_only, ensure_server_document,
-                              track_analytics)
+from utils.middleware import (admins_only, defer_interaction,
+                              ensure_server_document, track_analytics)
 
 
 class Channels(commands.GroupCog, name="settings"):
@@ -16,29 +15,23 @@ class Channels(commands.GroupCog, name="settings"):
         self.client = client
 
     @discord.app_commands.command(name="timezone", description="Admins only: Change the timezone")
+    @defer_interaction(ephemeral_default=True)
     @ensure_server_document
     @admins_only
     @track_analytics
     async def set_timezone(self, interaction: discord.Interaction, timezone: str) -> None:
         logger.info("file: cogs/admin.py ~ settings timezone ~ run")
 
-        if not interaction.guild or not isinstance(interaction.channel, discord.TextChannel) or not isinstance(interaction.user, discord.Member):
-            embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-
         if timezone not in pytz.all_timezones:
             embed = invalid_timezone_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
-
-        await interaction.response.defer(ephemeral=True)
 
         server_id = interaction.guild.id
         await Server.find_one(Server.id == server_id).update(Set({Server.timezone: timezone}))
 
         embed = timezone_updated_embed()
-        await interaction.followup.send(embed=embed, ephemeral=True)
+        await interaction.followup.send(embed=embed)
 
 
 async def setup(client: commands.Bot):

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -8,8 +8,8 @@ from embeds.channels_embeds import (
     set_channels_instructions_embed)
 from embeds.misc_embeds import error_embed
 from models.server_model import Server
-from utils.middleware import (admins_only, ensure_server_document,
-                              track_analytics)
+from utils.middleware import (admins_only, defer_interaction,
+                              ensure_server_document, track_analytics)
 from utils.views import ChannelsSelectView
 
 
@@ -18,16 +18,12 @@ class Channels(commands.GroupCog, name="notify-channel"):
         self.client = client
 
     @discord.app_commands.command(name="enable", description="Admins only: Set which channels should receive notifications")
+    @defer_interaction(ephemeral_default=True)
     @ensure_server_document
     @admins_only
     @track_analytics
     async def enable(self, interaction: discord.Interaction, channel: discord.TextChannel | None = None) -> None:
         logger.info("file: cogs/channels.py ~ notify-channel enable ~ run")
-
-        if not interaction.guild or not isinstance(interaction.channel, discord.TextChannel) or not isinstance(interaction.user, discord.Member):
-            embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
 
         if channel is None:
             channel = interaction.channel
@@ -42,26 +38,22 @@ class Channels(commands.GroupCog, name="notify-channel"):
 
         if all(channel.id in notification_type[1] for notification_type in server.channels):
             embed = channel_receiving_all_notification_types_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         available_types = [
             notification_type[0] for notification_type in server.channels if channel.id not in notification_type[1]]
 
         embed = set_channels_instructions_embed(channel.name, adding=True)
-        await interaction.response.send_message(embed=embed, view=ChannelsSelectView(server_id, channel.id, channel.name, available_types, adding=True), ephemeral=True)
+        await interaction.followup.send(embed=embed, view=ChannelsSelectView(server_id, channel.id, channel.name, available_types, adding=True))
 
     @discord.app_commands.command(name="disable", description="Admins only: Stop channel from receiving selected notification types")
+    @defer_interaction(ephemeral_default=True)
     @ensure_server_document
     @admins_only
     @track_analytics
     async def disable(self, interaction: discord.Interaction, channel: discord.TextChannel | None = None) -> None:
         logger.info("file: cogs/channels.py ~ notify-channel disable ~ run")
-
-        if not interaction.guild or not isinstance(interaction.channel, discord.TextChannel) or not isinstance(interaction.user, discord.Member):
-            embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
 
         if channel is None:
             channel = interaction.channel
@@ -76,14 +68,14 @@ class Channels(commands.GroupCog, name="notify-channel"):
 
         if all(channel.id not in notification_type[1] for notification_type in server.channels):
             embed = channel_receiving_no_notification_types_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         available_types = [
             notification_type[0] for notification_type in server.channels if channel.id in notification_type[1]]
 
         embed = set_channels_instructions_embed(channel.name, adding=False)
-        await interaction.response.send_message(embed=embed, view=ChannelsSelectView(server_id, channel.id, channel.name, available_types, adding=False), ephemeral=True)
+        await interaction.followup.send(embed=embed, view=ChannelsSelectView(server_id, channel.id, channel.name, available_types, adding=False))
 
 
 async def setup(client: commands.Bot):

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -3,7 +3,7 @@ from discord.ext import commands
 
 from bot_globals import logger
 from embeds.general_embeds import COMMAND_CATEGORIES, help_embed
-from utils.middleware import track_analytics
+from utils.middleware import defer_interaction, track_analytics
 from utils.views import CommandTypeSelectView
 
 
@@ -12,6 +12,7 @@ class General(commands.Cog):
         self.client = client
 
     @discord.app_commands.command(name="help", description="Help for CodeGrind Bot")
+    @defer_interaction(ephemeral_default=True)
     @track_analytics
     async def help(self, interaction: discord.Interaction) -> None:
         logger.info("file: cogs/help.py ~ help ~ run")
@@ -20,15 +21,17 @@ class General(commands.Cog):
         embed.set_footer(
             text="Love our bot? Vote on top.gg using /vote")
 
-        await interaction.response.send_message(embed=embed, view=CommandTypeSelectView(COMMAND_CATEGORIES), ephemeral=True)
+        await interaction.followup.send(embed=embed, view=CommandTypeSelectView(COMMAND_CATEGORIES))
 
     @discord.app_commands.command(name="vote", description="Vote for the bot on top.gg")
+    @defer_interaction(ephemeral_default=True)
     @track_analytics
     async def vote(self, interaction: discord.Interaction) -> None:
-        embed = discord.Embed(title="Vote for the bot on top.gg: ",
+        embed = discord.Embed(title="Vote for CodeGrind Bot on top.gg ",
                               description="https://top.gg/bot/1059122559066570885/vote",
-                              color=discord.Color.blue())
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+                              color=discord.Color.purple())
+
+        await interaction.followup.send(embed=embed)
 
 
 async def setup(client: commands.Bot):

--- a/cogs/leaderboards.py
+++ b/cogs/leaderboards.py
@@ -2,9 +2,9 @@ import discord
 from discord.ext import commands
 
 from bot_globals import logger
-from embeds.misc_embeds import error_embed
 from utils.leaderboards import display_leaderboard
-from utils.middleware import ensure_server_document, track_analytics, topgg_vote_required
+from utils.middleware import (defer_interaction, ensure_server_document,
+                              topgg_vote_required, track_analytics)
 
 
 class Leaderboards(commands.GroupCog, name="leaderboard"):
@@ -13,94 +13,58 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
         super().__init__()
 
     @discord.app_commands.command(name="alltime", description="View the All-Time leaderboard")
+    @defer_interaction()
     @ensure_server_document
     @track_analytics
     async def alltime(self, interaction: discord.Interaction, page: int = 1) -> None:
         logger.info("file: cogs/leaderboards.py ~ alltime ~ run")
 
-        await interaction.response.defer()
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.followup.send(embed=embed)
-            return
-
         await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "alltime", page)
 
     @discord.app_commands.command(name="weekly", description="View the Weekly leaderboard")
+    @defer_interaction()
     @ensure_server_document
     @track_analytics
     async def weekly(self, interaction: discord.Interaction, page: int = 1) -> None:
         logger.info("file: cogs/leaderboards.py ~ weekly ~ run")
 
-        await interaction.response.defer()
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.followup.send(embed=embed)
-            return
-
         await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "weekly", page)
 
     @discord.app_commands.command(name="daily", description="View the Daily leaderboard")
+    @defer_interaction()
     @ensure_server_document
     @track_analytics
     async def daily(self, interaction: discord.Interaction, page: int = 1) -> None:
         logger.info("file: cogs/leaderboards.py ~ daily ~ run")
 
-        await interaction.response.defer()
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.followup.send(embed=embed)
-            return
-
         await display_leaderboard(interaction.followup.send, interaction.guild.id, interaction.user.id, "daily", page)
 
     @discord.app_commands.command(name="global-alltime", description="View the Global All-Time leaderboard")
+    @defer_interaction()
     @topgg_vote_required
     @track_analytics
     async def global_alltime(self, interaction: discord.Interaction, page: int = 1) -> None:
         logger.info("file: cogs/leaderboards.py ~ global_alltime ~ run")
 
-        await interaction.response.defer()
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.followup.send(embed=embed)
-            return
-
         # Default server_id is 0 which is the global leaderboard.
         await display_leaderboard(interaction.followup.send, user_id=interaction.user.id, timeframe="alltime", page=page, global_leaderboard=True)
 
     @discord.app_commands.command(name="global-weekly", description="View the Global Weekly leaderboard")
+    @defer_interaction()
     @topgg_vote_required
     @track_analytics
     async def global_weekly(self, interaction: discord.Interaction, page: int = 1) -> None:
         logger.info("file: cogs/leaderboards.py ~ global_weekly ~ run")
 
-        await interaction.response.defer()
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.followup.send(embed=embed)
-            return
-
         # Default server_id is 0 which is the global leaderboard.
         await display_leaderboard(interaction.followup.send, user_id=interaction.user.id, timeframe="weekly", page=page, global_leaderboard=True)
 
     @discord.app_commands.command(name="global-daily", description="View the Global Daily leaderboard")
+    @defer_interaction()
     @topgg_vote_required
     @track_analytics
     async def global_daily(self, interaction: discord.Interaction, page: int = 1) -> None:
         logger.info("file: cogs/leaderboards.py ~ global_daily ~ run")
-
-        await interaction.response.defer()
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.followup.send(embed=embed)
-            return
 
         # Default server_id is 0 which is the global leaderboard.
         await display_leaderboard(interaction.followup.send, user_id=interaction.user.id, timeframe="daily", page=page, global_leaderboard=True)

--- a/cogs/questions.py
+++ b/cogs/questions.py
@@ -3,11 +3,11 @@ import re
 import discord
 from discord.ext import commands
 
-from bot_globals import client, logger
+from bot_globals import logger
 from embeds.questions_embeds import (daily_question_embed,
                                      random_question_embed,
                                      search_question_embed)
-from utils.middleware import track_analytics
+from utils.middleware import track_analytics, defer_interaction
 
 
 class Questions(commands.GroupCog, name="question"):
@@ -15,36 +15,33 @@ class Questions(commands.GroupCog, name="question"):
         self.client = client
 
     @discord.app_commands.command(name="search", description="Search for a LeetCode question")
+    @defer_interaction()
     @track_analytics
     async def search_question(self, interaction: discord.Interaction, name_id_or_url: str) -> None:
         logger.info("file: cogs/questions.py ~ display_question ~ run")
-
-        await interaction.response.defer()
 
         embed = await search_question_embed(name_id_or_url)
 
         await interaction.followup.send(embed=embed)
 
     @discord.app_commands.command(name="daily", description="Get the daily question")
+    @defer_interaction()
     @track_analytics
     async def daily_question(self, interaction: discord.Interaction) -> None:
         logger.info("file: cogs/questions.py ~ get_daily ~ run")
-
-        await interaction.response.defer()
 
         embed = await daily_question_embed()
 
         await interaction.followup.send(embed=embed)
 
     @discord.app_commands.command(name="random", description="Get a random question of your desired difficulty")
+    @defer_interaction()
     @track_analytics
     async def random_question(self, interaction: discord.Interaction, difficulty: str = "random") -> None:
         logger.info(
             "file: cogs/questions.py ~ question ~ run ~ difficulty: %s", difficulty)
 
         difficulty = difficulty.lower()
-
-        await interaction.response.defer()
 
         embed = await random_question_embed(difficulty)
 

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -2,12 +2,11 @@ import discord
 from discord.ext import commands
 
 from bot_globals import logger
-from embeds.misc_embeds import error_embed
 from embeds.roles_embeds import (missing_manage_roles_permission_embed,
                                  roles_created_embed, roles_removed_embed)
 from models.server_model import Server
-from utils.middleware import (admins_only, ensure_server_document,
-                              track_analytics)
+from utils.middleware import (admins_only, defer_interaction,
+                              ensure_server_document, track_analytics)
 from utils.roles import create_roles, remove_roles, update_roles
 
 
@@ -16,18 +15,12 @@ class Roles(commands.GroupCog, name="roles"):
         self.client = client
 
     @discord.app_commands.command(name="enable", description="Admins only: create and give CodeGrind roles to users")
+    @defer_interaction(ephemeral_default=True)
     @ensure_server_document
     @admins_only
     @track_analytics
     async def enable(self, interaction: discord.Interaction):
         logger.info("file: cogs/roles.py ~ roles enable ~ run")
-
-        if not interaction.guild or not isinstance(interaction.channel, discord.TextChannel) or not isinstance(interaction.user, discord.Member):
-            embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-
-        await interaction.response.defer(ephemeral=True)
 
         if not interaction.guild.me.guild_permissions.manage_roles:
             embed = missing_manage_roles_permission_embed()
@@ -44,18 +37,12 @@ class Roles(commands.GroupCog, name="roles"):
         await interaction.followup.send(embed=embed)
 
     @discord.app_commands.command(name="disable", description="Admins only: remove CodeGrind roles from users")
+    @defer_interaction(ephemeral_default=True)
     @ensure_server_document
     @admins_only
     @track_analytics
     async def disable(self, interaction: discord.Interaction):
         logger.info("file: cogs/roles.py ~ roles disable ~ run")
-
-        if not interaction.guild or not isinstance(interaction.channel, discord.TextChannel) or not isinstance(interaction.user, discord.Member):
-            embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-
-        await interaction.response.defer(ephemeral=True)
 
         if not interaction.guild.me.guild_permissions.manage_roles:
             embed = missing_manage_roles_permission_embed()

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -2,11 +2,10 @@ import discord
 from discord.ext import commands
 
 from bot_globals import logger
-from embeds.misc_embeds import error_embed
 from embeds.stats_embeds import account_hidden_embed, stats_embed
 from embeds.users_embeds import account_not_found_embed
 from models.user_model import User
-from utils.middleware import track_analytics
+from utils.middleware import defer_interaction, track_analytics
 
 
 class Stats(commands.Cog):
@@ -14,16 +13,10 @@ class Stats(commands.Cog):
         self.client = client
 
     @discord.app_commands.command(name="stats", description="Displays a user's stats")
+    @defer_interaction()
     @track_analytics
-    async def stats(self, interaction: discord.Interaction, user: discord.Member | None = None, display_publicly: bool = True, heatmap: bool = False) -> None:
+    async def stats(self, interaction: discord.Interaction, user: discord.Member | None = None, display_publicly: bool | None = None, heatmap: bool = False) -> None:
         logger.info('file: cogs/stats.py ~ stats ~ run')
-
-        await interaction.response.defer(ephemeral=not display_publicly)
-
-        if not interaction.guild:
-            embed = error_embed()
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
 
         if user:
             user_id = user.id

--- a/embeds/general_embeds.py
+++ b/embeds/general_embeds.py
@@ -48,7 +48,7 @@ You can view our Privacy Policy [here](https://github.com/CodeGrind-Team/CodeGri
 
 </leaderboard alltime:1115756888664060015>: Returns the all-time leaderboard stats
 
-### Global leaderboard (must vote on top.gg first, use </vote:1122529789056647198>)
+### Global leaderboard (</vote:1122529789056647198> on top.gg to gain access to these commands)
 </leaderboard global-daily:1115756888664060015>: Returns today's leaderboard stats which resets at midnight (UTC)
 
 </leaderboard global-weekly:1115756888664060015>: Returns the week's leaderboard stats which resets on Sunday at midnight (UTC)

--- a/embeds/questions_embeds.py
+++ b/embeds/questions_embeds.py
@@ -78,5 +78,5 @@ def premium_question_embed(question_id, title, link, color: discord.Color) -> di
 
 def question_error_embed() -> discord.Embed:
     embed = discord.Embed(
-        title="Question could not be retrieved", color=discord.Color.red())
+        title="Question could not be found", color=discord.Color.red())
     return embed

--- a/embeds/topgg_embeds.py
+++ b/embeds/topgg_embeds.py
@@ -11,6 +11,6 @@ def topgg_not_voted() -> discord.Embed:
     embed.description = f"You can vote [here]({url})"
 
     embed.set_footer(
-        text="Note: votes are reset on the first day of each month")
+        text="Note: votes are reset every 12 hours")
 
     return embed

--- a/embeds/users_embeds.py
+++ b/embeds/users_embeds.py
@@ -45,10 +45,9 @@ def connect_account_instructions_embed(generated_string: str, leetcode_username:
 
 
 def profile_added_embed(leetcode_username: str, added: bool = True) -> discord.Embed:
-    embed = discord.Embed(title=f"Profile {'' if added else 'not '}added",
+    embed = discord.Embed(title=f"LeetCode account {'' if added else 'not '}added",
                           color=discord.Color.green() if added else discord.Color.red())
-    embed.add_field(name="Username:",
-                    value=f"{leetcode_username}", inline=False)
+    embed.description = f"**LeetCode ID**: {leetcode_username}\n\nYou can now revert or change your LeetCode Name to whatever you desire."
 
     return embed
 

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -142,7 +142,12 @@ def search_question(text: str) -> str | None:
 
     response_data = response.json()
 
-    question_title_slug = response_data['data']['problemsetQuestionList']['questions'][0]['titleSlug']
+    questions_matched_list = response_data['data']['problemsetQuestionList']
+
+    if not questions_matched_list:
+        return
+
+    question_title_slug = questions_matched_list['questions'][0]['titleSlug']
 
     return question_title_slug
 

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -109,6 +109,8 @@ async def update_stats(user: User, now: datetime, daily_reset: bool = False, wee
         if not member:
             await Server.find_one(Server.id == user.display_information[i].server_id).update(Pull({"users": {"$id": user.id}}))
             del user.display_information[i]
+            logger.info(
+                "file: utils/stats.py ~ update_stats ~ user unlinked from server ~ user_id: %s, server_id: %s", user.id, guild.id)
             continue
 
         user.display_information[i].name = member.display_name


### PR DESCRIPTION
## Problem
Due to the topgg_vote_required decorator that was running code for a duration of time before the interaction was deferred, 'interaction has failed' errors were caused. 

## Solution
To resolve this, a defer_interaction decorator has been created that defers the message. It also checks if a `display_publicly` parameter is passed to the function which will be taken into consideration, alongside the ephemeral default state provided, when setting the ephemeral state of the response.

This also gave me the opportunity to move the repeated validation of the interaction variable within this new decorator which has decluttered most commands.

Other changes:
- Handle invalid search term for /question search.
- Update some command embed texts and colours.

> Research note: once a response is deferred, the ephemeral state of the message cannot be changed.

## How has it been tested
I've run all the commands to see if they work with different states and parameter values, and they all do.