### PR TITLE
Replace integer shortcut with DBRef when using AddToSet. and fix remove inactive users logic.

### DIFF
--- a/tests/database_utils/link_users_to_server.py
+++ b/tests/database_utils/link_users_to_server.py
@@ -25,7 +25,4 @@ async def link_user_to_server(user: User, server_id: int = 0) -> None:
         server_id=server_id, name=discord_user.name, url=False)
 
     await User.find_one(User.id == user.id).update(AddToSet({User.display_information: display_information}))
-    await Server.find_one(Server.id == server_id).update(AddToSet({Server.users: user.id}))
-    server = await Server.get(server_id)
-    # link rule to create a new document for the new link
-    await server.save()
+    await Server.find_one(Server.id == server_id).update(AddToSet({Server.users: DBRef("users",  user.id)}))

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -98,6 +98,15 @@ async def update_stats(user: User, now: datetime, daily_reset: bool = False, wee
     user.submissions.total_score = total_score
 
     for i in range(len(user.display_information)-1, -1, -1):
+        if display_information[i].server_id == 0:
+            discord_user = await client.fetch_user(user.id)
+
+            if discord_user is None:
+                continue
+
+            user.display_information[i].name = discord_user.name
+            continue
+
         guild = client.get_guild(user.display_information[i].server_id)
 
         if not guild:


### PR DESCRIPTION
Improved reliability through:
- Adding the DBRef directly using AddToSet rather than the shortcut that was previously used. This means that AddToSet won't add if the id already exists in the array. This also improves the speed as the server doesn't need to be manually saved every single time.
- Delete server only after the users are unlinked, so that there aren't any leftover display_informations.
- Set default user's display name for global leaderboard when stats updates.