### PR TITLE
Get users name for global server display information

### DIFF
--- a/utils/analytics_utils.py
+++ b/utils/analytics_utils.py
@@ -1,0 +1,22 @@
+from database.models.analytics_model import Analytics, AnalyticsHistory
+from bot_globals import logger
+
+
+async def save_analytics() -> None:
+    logger.info("file: cogs/analytics_utils.py ~ save_analytics ~ run")
+
+    analytics = await Analytics.find_all().to_list()
+
+    if not analytics:
+        analytics = Analytics()
+        await analytics.create()
+    else:
+        analytics = analytics[0]
+
+    analytics.history.append(AnalyticsHistory(
+        distinct_users=analytics.distinct_users_today, command_count=analytics.command_count_today))
+
+    analytics.distinct_users_today = []
+    analytics.command_count_today = 0
+
+    await analytics.save()

--- a/utils/leaderboards_utils.py
+++ b/utils/leaderboards_utils.py
@@ -2,6 +2,8 @@ from collections import Counter
 from datetime import datetime, timedelta
 
 import discord
+from beanie.odm.operators.update.array import AddToSet
+from bson import DBRef
 
 from bot_globals import RANK_EMOJI, TIMEFRAME_TITLE, client, logger
 from database.models.server_model import Server
@@ -147,3 +149,10 @@ async def send_leaderboard_winners(server: Server, timeframe: str) -> None:
 
     logger.info(
         "file: utils/leaderboards_utils.py ~ send_leaderboard_winners ~ %s winners leaderboard sent to channels", timeframe)
+
+
+async def update_global_leaderboard() -> None:
+    """Add all users to the global server in case anyone is missing.
+    """
+    async for user in User.all():
+        await Server.find_one(Server.id == 0).update(AddToSet({Server.users: DBRef("users",  user.id)}))

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -115,8 +115,16 @@ async def update_stats(user: User, now: datetime, daily_reset: bool = False, wee
 
 
 async def update_display_information_names(user: User) -> None:
+    logger.info(
+        "file: cogs/stats_utils.py ~ update_display_information_names ~ run ~ user: %s", user.id)
+
     for i in range(len(user.display_information)-1, -1, -1):
         if user.display_information[i].server_id == 0:
+            discord_user = client.get_user(user.id)
+
+            if discord_user:
+                user.display_information[i].name = discord_user.name
+
             continue
 
         guild = client.get_guild(user.display_information[i].server_id)

--- a/utils/users_utils.py
+++ b/utils/users_utils.py
@@ -1,0 +1,50 @@
+from beanie.odm.operators.update.array import Pull
+
+from bot_globals import client, logger
+from database.models.server_model import Server
+from database.models.user_model import User
+
+
+async def remove_inactive_users() -> None:
+    async for server in Server.all():
+        # Make exception for global leaderboard server.
+        if server.id == 0:
+            continue
+
+        # So that we can access user.id
+        await server.fetch_all_links()
+
+        guild = client.get_guild(server.id)
+
+        delete_server = False
+        # Delete server document if the bot isn't in the server anymore
+        if not guild or guild not in client.guilds:
+            delete_server = True
+
+        for user in server.users:
+            # unlink user if server was deleted or if bot not in the server anymore
+            unlink_user = not guild or not guild.get_member(
+                user.id) or delete_server
+
+            # Unlink user from server if they're not in the server anymore
+            if unlink_user:
+                await User.find_one(User.id == user.id).update(Pull({User.display_information: {"server_id": server.id}}))
+                await Server.find_one(Server.id == server.id).update(Pull({Server.users: {"$id": user.id}}))
+
+                logger.info(
+                    "file: utils/notifications_utils.py ~ remove_inactive_users ~ user unlinked from server ~ user_id: %s, server_id: %s", user.id, server.id)
+
+        if delete_server:
+            await server.delete()
+
+            logger.info(
+                "file: utils/notifications_utils.py ~ remove_inactive_users ~ server document deleted ~ id: %s", server.id)
+
+    async for user in User.all():
+        # Delete user document if they're not in any server with the bot in it except the global leaderboard
+        if len(user.display_information) == 1:
+            await Server.find_one(Server.id == 0).update(Pull({Server.users: {"$id": user.id}}))
+            await user.delete()
+
+            logger.info(
+                "file: utils/notifications_utils.py ~ remove_inactive_users ~ user document deleted ~ id: %s", user.id)


### PR DESCRIPTION
- Replaced `client.fetch_user` (which is a coroutine), with `client.get_user` which will not lead to ratelimit.
- Separated code in `notifications_utils.py` and `stats_utils.py ` into more appropriate files.