### PR TITLE
Prevent unlinking of users if user is not a member of guild in cache

### DIFF
--- a/middleware/database_middleware.py
+++ b/middleware/database_middleware.py
@@ -56,6 +56,9 @@ async def update_user_preferences_prompt(interaction: discord.Interaction, remin
     user = await User.find_one(
         User.id == interaction.user.id)
 
+    if not user:
+        return
+
     display_information = next(
         (di for di in user.display_information if di.server_id == interaction.guild.id), None)
 

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -135,10 +135,8 @@ async def update_display_information_names(user: User) -> None:
         member = guild.get_member(user.id)
 
         if not member:
-            await Server.find_one(Server.id == user.display_information[i].server_id).update(Pull({"users": {"$id": user.id}}))
-            del user.display_information[i]
             logger.info(
-                "file: utils/stats.py ~ update_stats ~ user unlinked from server ~ user_id: %s, server_id: %s", user.id, guild.id)
+                "file: utils/stats.py ~ update_stats ~ user not a member of server ~ user_id: %s, server_id: %s", user.id, guild.id)
             continue
 
         user.display_information[i].name = member.display_name


### PR DESCRIPTION
- Realised that there was no need for filtering out the display informations in user stats, so I removed the code that removes the user's display_information and unlinks them from the corresponding server. The monthly pruning will be responsible for the unlinking.
- Return None if user not found in `update_user_preferences_prompt`