### PR TITLE
fix: Prevent discord channel logger rate limit

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ async def setup_hook() -> None:
         logger.info(
             "file: main.py ~ setup_hook ~ synced %s commands", len(synced))
 
-        # send_daily_question_and_update_stats_schedule.start()
+        send_daily_question_and_update_stats_schedule.start()
 
     except Exception as e:
         logger.exception("file: main.py ~ setup_hook ~ exception: %s", e)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from utils.notifications_utils import (
     send_daily_question_and_update_stats,
     send_daily_question_and_update_stats_schedule)
 from utils.ratings_utils import read_ratings_txt
+from utils.dev_utils import ChannelLogger
 
 load_dotenv()
 
@@ -52,11 +53,14 @@ async def setup_hook() -> None:
             client, dbl_token, autopost=True, post_shard_count=True)
 
     try:
+        LOGGING_CHANNEL_ID = int(os.environ['LOGGING_CHANNEL_ID'])
+        client.channel_logger = ChannelLogger(LOGGING_CHANNEL_ID)
+
         synced = await client.tree.sync()
         logger.info(
             "file: main.py ~ setup_hook ~ synced %s commands", len(synced))
 
-        send_daily_question_and_update_stats_schedule.start()
+        # send_daily_question_and_update_stats_schedule.start()
 
     except Exception as e:
         logger.exception("file: main.py ~ setup_hook ~ exception: %s", e)

--- a/utils/notifications_utils.py
+++ b/utils/notifications_utils.py
@@ -15,7 +15,6 @@ from utils.leaderboards_utils import (send_leaderboard_winners,
 from utils.roles_utils import update_roles
 from utils.stats_utils import update_rankings, update_stats
 from utils.users_utils import remove_inactive_users
-from utils.dev_utils import log_to_channel, LogType
 
 
 async def send_daily_question(server: Server, embed: discord.Embed) -> None:
@@ -66,7 +65,7 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
                12 and now.minute == 0)
 
     if force_update_stats:
-        await log_to_channel(LogType.INFO, "Started updating users stats")
+        await client.channel_logger.INFO("Started updating users stats")
         async with aiohttp.ClientSession() as client_session:
             tasks = []
             async for user in User.all():
@@ -79,9 +78,9 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
 
         await update_global_leaderboard()
 
-        await log_to_channel(LogType.INFO, "Completed updating users stats")
+        await client.channel_logger.INFO("Completed updating users stats", include_rate_limit_count=True)
 
-    await log_to_channel(LogType.INFO, "Started updating server rankings")
+    await client.channel_logger.INFO("Started updating server rankings")
     async for server in Server.all(fetch_links=True):
         server.last_updated = now
         await server.save()
@@ -97,7 +96,7 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
         if midday:
             await update_roles(server)
 
-    await log_to_channel(LogType.INFO, "Completed updating server rankings")
+    await client.channel_logger.INFO("Completed updating server rankings")
 
     if daily_reset:
         embed = await daily_question_embed()
@@ -108,9 +107,9 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
         await save_analytics()
 
     if monthly:
-        await log_to_channel(LogType.INFO, "Started pruning")
+        await client.channel_logger.INFO("Started pruning")
         await remove_inactive_users()
-        await log_to_channel(LogType.INFO, "Completed pruning")
+        await client.channel_logger.INFO("Completed pruning")
 
     logger.info(
         "file: utils/notifications_utils.py ~ send_daily_question_and_update_stats ~ ended")

--- a/utils/questions_utils.py
+++ b/utils/questions_utils.py
@@ -9,12 +9,11 @@ from typing import List, Any
 import markdownify
 import requests
 
-from bot_globals import logger
+from bot_globals import logger, client
 from utils.common_utils import to_thread
 from utils.ratings_utils import get_rating_data
-from utils.dev_utils import log_to_channel, LogType
 
-semaphore = asyncio.Semaphore(10)
+semaphore = asyncio.Semaphore(8)
 
 
 @to_thread
@@ -327,12 +326,12 @@ async def get_problems_solved_and_rank(client_session: aiohttp.ClientSession, le
         if response.status == 429:
             # Rate limit reached
             logger.exception(
-                "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ Error code: %s", response.status)
-            await log_to_channel(LogType.WARNING, "Rate limited")
+                "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ LeetCode username: %s ~ Error code: %s", leetcode_username, response.status)
+            client.channel_logger.rate_limited()
             raise RateLimitReached()
         elif response.status != 200:
             logger.exception(
-                "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ Error code: %s", response.status)
+                "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ LeetCode username: %s ~ Error code: %s", leetcode_username, response.status)
 
             return
 


### PR DESCRIPTION
Created `ChannelLogger` class that keeps track of the number of rate limits, and displays them all at once in one message.