### PR TITLE
Add headers to graphql requests. Add 403 error counting and channel logging.

### DIFF
--- a/automations/database_utils/create_dummy_users.py
+++ b/automations/database_utils/create_dummy_users.py
@@ -10,7 +10,7 @@ sys.path.append(parent_path)
 from beanie import init_beanie
 from beanie.odm.fields import WriteRules
 from beanie.odm.operators.update.array import AddToSet
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from utils.common_utils import calculate_scores
@@ -18,7 +18,7 @@ from database.models.server_model import Server
 from database.models.user_model import (DisplayInformation, Scores,
                                         Submissions, User)
 
-load_dotenv()
+load_dotenv(find_dotenv())
 
 
 async def create_user(server_id: int, user_id: int, leetcode_username: str, name: str, rank: int, url_bool: bool, easy: int, medium: int, hard: int):

--- a/automations/send_notification.py
+++ b/automations/send_notification.py
@@ -9,13 +9,13 @@ sys.path.append(parent_path)
 import asyncio
 import discord
 from beanie import init_beanie
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from motor.motor_asyncio import AsyncIOMotorClient
 from bot_globals import client
 from database.models.server_model import Server
 from database.models.user_model import User
 
-load_dotenv()
+load_dotenv(find_dotenv())
 
 
 @client.event

--- a/bot_globals.py
+++ b/bot_globals.py
@@ -5,10 +5,10 @@ from datetime import datetime
 import discord
 import pytz
 from discord.ext import commands
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from html2image import Html2Image
 
-load_dotenv()
+load_dotenv(find_dotenv())
 
 if not os.path.exists('logs'):
     os.makedirs('logs')

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 
 import discord
 import topgg
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 from bot_globals import client, logger
 from database.setup import init_mongodb_conn
@@ -14,7 +14,7 @@ from utils.notifications_utils import (
 from utils.ratings_utils import read_ratings_txt
 from utils.dev_utils import ChannelLogger
 
-load_dotenv()
+load_dotenv(find_dotenv())
 
 
 @client.event

--- a/utils/dev_utils.py
+++ b/utils/dev_utils.py
@@ -9,17 +9,25 @@ from random import random
 class ChannelLogger:
     def __init__(self, channel_id: int) -> None:
         self.rate_limits = 0
+        self.forbidden_count = 0
         self.channel_id = channel_id
 
     def rate_limited(self) -> None:
         self.rate_limits += 1
 
-    async def INFO(self, message: str, include_rate_limit_count: bool = False) -> None:
-        if include_rate_limit_count:
+    def forbidden(self) -> None:
+        self.forbidden_count += 1
+
+    async def INFO(self, message: str, include_error_counts: bool = False) -> None:
+        if include_error_counts:
             message += f". Rate limited {self.rate_limits} times"
             self.rate_limits = 0
 
         await self.log(message, discord.Color.blue())
+
+        if include_error_counts:
+            await self.WARNING(f"Forbidden {self.forbidden_count} times.")
+            self.forbidden_count = 0
 
     async def WARNING(self, message: str) -> None:
         await self.log(message, discord.Color.orange())

--- a/utils/notifications_utils.py
+++ b/utils/notifications_utils.py
@@ -78,7 +78,7 @@ async def send_daily_question_and_update_stats(force_update_stats: bool = True, 
 
         await update_global_leaderboard()
 
-        await client.channel_logger.INFO("Completed updating users stats", include_rate_limit_count=True)
+        await client.channel_logger.INFO("Completed updating users stats", include_error_counts=True)
 
     await client.channel_logger.INFO("Started updating server rankings")
     async for server in Server.all(fetch_links=True):

--- a/utils/questions_utils.py
+++ b/utils/questions_utils.py
@@ -349,6 +349,11 @@ async def get_problems_solved_and_rank(client_session: aiohttp.ClientSession, le
                 "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ LeetCode username: %s ~ Error code: %s", leetcode_username, response.status)
             client.channel_logger.rate_limited()
             raise RateLimitReached()
+        elif response.status == 403:
+            logger.exception(
+                "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ LeetCode username: %s ~ Error code: %s", leetcode_username, response.status)
+            client.channel_logger.forbidden()
+            return
         elif response.status != 200:
             logger.exception(
                 "file: utils/questions_utils.py ~ get_problems_solved_and_rank ~ LeetCode username: %s ~ Error code: %s", leetcode_username, response.status)

--- a/utils/questions_utils.py
+++ b/utils/questions_utils.py
@@ -63,6 +63,11 @@ def get_daily_question() -> str | None:
 
     headers = {
         'Content-Type': 'application/json',
+        'Origin': 'https://leetcode.com',
+        'Referer': 'https://leetcode.com',
+        'Cookie': 'csrftoken=; LEETCODE_SESSION=;',
+        'x-csrftoken': '',
+        'user-agent': 'Mozilla/5.0 LeetCode API'
     }
 
     data = {
@@ -112,6 +117,11 @@ def search_question(text: str) -> str | None:
 
     headers = {
         'Content-Type': 'application/json',
+        'Origin': 'https://leetcode.com',
+        'Referer': 'https://leetcode.com',
+        'Cookie': 'csrftoken=; LEETCODE_SESSION=;',
+        'x-csrftoken': '',
+        'user-agent': 'Mozilla/5.0 LeetCode API'
     }
 
     data = {
@@ -166,6 +176,11 @@ def get_question_info_from_title(question_title_slug: str) -> List[int | str] | 
 
     headers = {
         'Content-Type': 'application/json',
+        'Origin': 'https://leetcode.com',
+        'Referer': 'https://leetcode.com',
+        'Cookie': 'csrftoken=; LEETCODE_SESSION=;',
+        'x-csrftoken': '',
+        'user-agent': 'Mozilla/5.0 LeetCode API'
     }
 
     # Get question info
@@ -284,6 +299,11 @@ async def get_problems_solved_and_rank(client_session: aiohttp.ClientSession, le
 
     headers = {
         'Content-Type': 'application/json',
+        'Origin': 'https://leetcode.com',
+        'Referer': 'https://leetcode.com',
+        'Cookie': 'csrftoken=; LEETCODE_SESSION=;',
+        'x-csrftoken': '',
+        'user-agent': 'Mozilla/5.0 LeetCode API'
     }
 
     data = {


### PR DESCRIPTION
From around 07/03/2024, using LeetCode's API led to 403 status code responses (forbidden access). So, for a potential fix, I copied the headers used in https://github.com/JacobLinCool/LeetCode-Query, because https://github.com/JacobLinCool/LeetCode-Stats-Card works as intended.

- Added new headers.
- Added find_dotenv.
- Added 403 error counting and logging to Discord channel.