### PR TITLE
Handle premium questions which don't have content

### DIFF
--- a/ui/constants.py
+++ b/ui/constants.py
@@ -78,12 +78,12 @@ Credit to [LeetCode Stats Card](https://github.com/JacobLinCool/LeetCode-Stats-C
     CommandCategory.LEETCODE_PROBLEMS: """
 ## LeetCode Problems
 
-</problem daily:1243563243147100301>: Returns LeetCode's problem of the day
+</problem daily:1243573686666137673>: Returns LeetCode's problem of the day
 
-</problem random:1243563243147100301>: Returns a random LeetCode question.
+</problem random:1243573686666137673>: Returns a random LeetCode question.
 >    - `difficulty` _(optional)_: A difficulty level (easy, medium or hard). By default this will be set to a random difficulty level.
 
-</problem search:1243563243147100301>: Display your searched LeetCode question.""",
+</problem search:1243573686666137673>: Display your searched LeetCode question.""",
     CommandCategory.ROLES: """
 ## Roles
 
@@ -117,7 +117,7 @@ These commands are only available to administrators of this server.
 
 ## Notifications
 
-</notifications:1243563243147100300>: Sends daily notifications at midnight (UTC) to the specified channel.
+</notifications:1243573686666137672>: Sends daily notifications at midnight (UTC) to the specified channel.
 >    - `channel` _(optional)_: The channel (e.g. "#home-channel") to send notifications to. By default this will be the channel where you ran this command.
 
 Note: please press the 'save' button twice!

--- a/ui/embeds/problems.py
+++ b/ui/embeds/problems.py
@@ -109,7 +109,7 @@ def premium_question_embed(
 ) -> discord.Embed:
     return discord.Embed(
         title=f"{question_id}. {title}",
-        description="Cannot display premium questions",
+        description="Premium Question",
         url=link,
         colour=colour,
     )

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -370,9 +370,7 @@ async def fetch_question_info(
         difficulty = question["difficulty"]
         title = question["title"]
         is_paid_only = question["isPaidOnly"]
-        content = (
-            question["content"] if not is_paid_only else "LeetCode Premium question"
-        )
+        content = question["content"] if not is_paid_only else ""
         link = f"https://leetcode.com/problems/{question_title_slug}"
 
         stats = ast.literal_eval(question["stats"])

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -330,7 +330,8 @@ async def fetch_question_info(
     :return: Information about the LeetCode question, or None if an error occurs or no
              question is found.
     """
-    # Get question info
+    bot.logger.info(f"Fetched question with title: {question_title_slug}")
+
     payload = {
         "operationName": "questionInfo",
         "query": """
@@ -368,8 +369,10 @@ async def fetch_question_info(
         question_id = question["questionFrontendId"]
         difficulty = question["difficulty"]
         title = question["title"]
-        content = question["content"]
         is_paid_only = question["isPaidOnly"]
+        content = (
+            question["content"] if not is_paid_only else "LeetCode Premium question"
+        )
         link = f"https://leetcode.com/problems/{question_title_slug}"
 
         stats = ast.literal_eval(question["stats"])


### PR DESCRIPTION
If a premium question is retrieved, now checks if it is a premium question and if it is, sets the content to an empty string in order to prevent a ValueError.