### PR TITLE
Handle missing required permissions to send daily question to channel

### DIFF
--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -129,7 +129,13 @@ async def send_daily_question(
         if not channel or not isinstance(channel, discord.TextChannel):
             continue
 
-        await channel.send(embed=embed, silent=True)
+        try:
+            await channel.send(embed=embed, silent=True)
+        except discord.errors.Forbidden:
+            bot.logger.info(
+                f"Forbidden to share daily question to channel with ID: "
+                f"{channel_id}"
+            )
 
 
 async def update_all_user_stats(bot: "DiscordBot", reset_day: int = False) -> None:

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -410,7 +410,7 @@ async def fetch_question_info(
     )
 
 
-@backoff.on_exception(backoff.expo, RateLimitReached)
+@backoff.on_exception(backoff.expo, RateLimitReached, logger=None)
 async def fetch_problems_solved_and_rank(
     bot: "DiscordBot", client_session: aiohttp.ClientSession, leetcode_id: str
 ) -> UserStats | None:


### PR DESCRIPTION
Added try except to channel.send when sending the daily question notifications, in the scenario that the bot has missing permissions.