### PR TITLE
Catch raised Forbidden error when updating roles

### DIFF
--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -66,7 +66,8 @@ async def process_daily_question_and_stats_update(
 
         async for server in Server.all(fetch_links=True):
             await send_daily_question(bot, server, embed)
-            bot.logger.info("Daily question sent to all")
+
+        bot.logger.info("Daily question sent to all servers")
 
     if update_stats:
         await update_all_user_stats(bot, reset_day)
@@ -87,28 +88,24 @@ async def process_daily_question_and_stats_update(
 
         if reset_day:
             await send_leaderboard_winners(bot, server, Period.DAY)
-            bot.logger.info(
-                "Daily winners leaderboard sent to all channels",
-            )
 
         if reset_week:
             await send_leaderboard_winners(bot, server, Period.WEEK)
-            bot.logger.info(
-                "Weekly winners leaderboard sent to all channels",
-            )
 
         if reset_month:
             await send_leaderboard_winners(bot, server, Period.MONTH)
-            bot.logger.info(
-                "Monthly winners leaderboard sent to all channels",
-            )
 
         if midday:
             if guild := bot.get_guild(server.id):
-                bot.logger.info(
-                    "Updating roles",
-                )
-                await update_roles(guild, server.id)
+                try:
+                    await update_roles(guild, server.id)
+                except discord.errors.Forbidden:
+                    # Missing permissions are handled inside update_roles, so it
+                    # shouldn't raise an error.
+                    bot.logger.info(
+                        f"Forbidden to add roles to members of server with ID: "
+                        f"{server.id}"
+                    )
 
     bot.logger.info("Sending daily notifications and updating stats completed")
     await bot.channel_logger.info("Completed updating")

--- a/utils/roles.py
+++ b/utils/roles.py
@@ -100,7 +100,7 @@ async def update_roles(guild: discord.Guild, server_id: int) -> None:
     Update roles for users in the server based on their stats.
 
     :param guild: The guild in which to update the roles.
-    :param server: The server model containing user stats.
+    :param server_id: The id of the server to update its roles.
     """
     if not guild.me.guild_permissions.manage_roles:
         return
@@ -124,10 +124,10 @@ async def update_roles(guild: discord.Guild, server_id: int) -> None:
 
 async def give_verified_role(guild: discord.Guild, member: discord.Member) -> None:
     """
-    Give the verified role to a user.
+    Give the verified role to a member.
 
     :param guild: The guild in which to give the role.
-    :param user: The user to whom to give the role.
+    :param member: The member to whom to give the role.
     """
     role = discord.utils.get(guild.roles, name=VERIFIED_ROLE)
 
@@ -145,7 +145,7 @@ async def give_streak_role(
     Give a streak role to a user based on their streak.
 
     :param guild: The guild in which to give the role.
-    :param user: The user to whom to give the role.
+    :param member: The member to whom to give the role.
     :param streak: The streak of the user.
     """
     role_to_assign = None
@@ -175,7 +175,7 @@ async def give_milestone_role(
     Give a milestone role to a user based on their total solved milestones.
 
     :param guild: The guild in which to give the role.
-    :param user: The user to whom to give the role.
+    :param member: The member to whom to give the role.
     :param total_solved: The total solved milestones of the user.
     """
     role_to_assign = None


### PR DESCRIPTION
Even though it is already checked whether the bot has `manage roles` permissions in the guild when updating roles, this still leads sometimes to a discord.errors.Forbidden error being raised when attempting to add roles to a member.

This should be delved a bit deeper to figure out the cause of this inconsistency, however as a temporary fix, we now except a forbidden error if raised to now crash the system.