### PR TITLE
Separate multiple record timestamp comparisions to retrieve the correct timestamp document

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -77,7 +77,7 @@ class DiscordBot(commands.Bot):
         """
         self.logger.info(
             f"Posted server count ({self.topggpy.guild_count}), shard count "
-            "({self.shard_count})",
+            f"({self.shard_count})",
         )
 
         self.logger.info(

--- a/ui/embeds/leaderboards.py
+++ b/ui/embeds/leaderboards.py
@@ -16,7 +16,12 @@ def empty_leaderboard_embed() -> discord.Embed:
 
 
 def leaderboard_embed(
-    server: Server, page_i: int, page_count: int, title: str, leaderboard: str
+    server: Server,
+    page_i: int,
+    page_count: int,
+    title: str,
+    leaderboard: str,
+    include_page_count: bool = True,
 ) -> discord.Embed:
     embed = discord.Embed(
         title=title, description=leaderboard, colour=discord.Colour.yellow()
@@ -36,11 +41,13 @@ def leaderboard_embed(
         .astimezone(pytz.timezone(server.timezone)),
     )
 
+    page_count_text = f"\nPage {page_i + 1}/{page_count}" if include_page_count else ""
+
     embed.set_footer(
         text=f"Easy: {DifficultyScore.EASY.value} point, Medium: "
         f"{DifficultyScore.MEDIUM.value} points, Hard: {DifficultyScore.HARD.value} "
-        f"points\nUpdated on {last_updated_start} - {last_updated_end}\nPage "
-        f"{page_i + 1}/{page_count}"
+        f"points\nUpdated on {last_updated_start} - {last_updated_end}"
+        f"{page_count_text}"
     )
 
     return embed

--- a/ui/embeds/problems.py
+++ b/ui/embeds/problems.py
@@ -116,4 +116,6 @@ def premium_question_embed(
 
 
 def question_error_embed() -> discord.Embed:
-    return failure_embed(title="Question could not be found")
+    return failure_embed(
+        title="There was a problem retrieving the question. Please try again later."
+    )

--- a/utils/leaderboards.py
+++ b/utils/leaderboards.py
@@ -69,7 +69,8 @@ async def get_score(user: User, period: Period, previous: bool) -> int:
 
         record_start = await Record.find_one(
             Record.user_id == user.id,
-            record_timestamp_start <= Record.timestamp < record_end.timestamp,
+            Record.timestamp >= record_timestamp_start,
+            Record.timestamp < record_timestamp_end,
         )
         if not record_start:
             return 0
@@ -284,7 +285,14 @@ async def build_leaderboard_page(
     title = get_title(period, winners_only, global_leaderboard)
 
     return (
-        leaderboard_embed(server, page_index, num_pages, title, "\n".join(leaderboard)),
+        leaderboard_embed(
+            server,
+            page_index,
+            num_pages,
+            title,
+            "\n".join(leaderboard),
+            include_page_count=not winners_only,
+        ),
         place,
         prev_score,
     )


### PR DESCRIPTION
Incorrect record timestamp was retrieved due to the single-line multiple comparison expressions when finding the document.

What has been done:
-  Separated the two timestamp expressions into single expressions.
- Added a missing f-string to a string.
- Added parameter to not display the page count if it's the daily winners leaderboard. As it's unnecessary for that data to be shown on a single page embed.