### PR TITLE
fix: Set `reconnect` to `False` to prevent silently handled exceptions in tasks, and add missing `response_data` `NoneType` check

### DIFF
--- a/cogs/notifications.py
+++ b/cogs/notifications.py
@@ -36,8 +36,8 @@ class NotificationsCog(commands.Cog):
 
         await interaction.followup.send(
             embed=discord.Embed(
-                description=f"Select whether you want to enable or disable \
-                    notifications in <#{channel.id}>"
+                description=f"Select whether you want to enable or disable "
+                f"notifications in <#{channel.id}>"
             ),
             view=SelectOperatorView(self.bot, channel),
         )

--- a/ui/constants.py
+++ b/ui/constants.py
@@ -32,9 +32,9 @@ class CommandCategory(Enum):
 CATEGORY_DESCRIPTIONS = {
     CommandCategory.HOME: f"""
 # About CodeGrind Bot
-CodeGrind Bot helps you master LeetCode by engaging in friendly competition with your friends through daily, weekly, monthly, and all-time server leaderboards. Simply connect your LeetCode account to this bot and you are ready to go!
+The all-in-one Discord bot for LeetCode users. Track and compare your LeetCode stats against friends in server leaderboards, alongside searching and viewing LeetCode questions directly within Discord.
 
-This bot also provides you commands to get a random LeetCode question, the LeetCode daily question, retrieve the Zerotrac rating of a question, and receive a notification of the LeetCode daily question and the daily/weekly winners leaderboards.
+> Please note: while the bot uses the LeetCode API for data, it's not officially affiliated with LeetCode.
 
 ## Score calculation
 Each connected user is assigned a score which calculated based on the amount of questions they have solved. 
@@ -113,18 +113,18 @@ These commands are only available to administrators of this server.
 
 ## Roles
 
-</roles:1204499698317262965>: Creates and gives verified CodeGrind user, score milestones, and streak roles that will be automatically updated each day at midday (UTC).
+</roles:1204499698317262965>: Enable/disable automatically giving verified CodeGrind user, score milestones, and streak roles that will be automatically updated each day at midday (UTC).
 
 ## Notifications
 
-</notifications:1243573686666137672>: Sends daily notifications at midnight (UTC) to the specified channel.
+</notifications:1243573686666137672>: Enable/disable daily notifications being sent at midnight (UTC) to a channel.
 >    - `channel` _(optional)_: The channel (e.g. "#home-channel") to send notifications to. By default this will be the channel where you ran this command.
 
 Note: please press the 'save' button twice!
 
 ## Settings
 
-</settings timezone:1204499698317262958>: Change the timezone of this server's leaderboards.
+</settings timezone:1204499698317262958>: Change the timezone on this server's leaderboards.
 >    - `timezone`: A timezone from the following list of timezones: https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568 .""",
     CommandCategory.CODEGRIND_TEAM: """
 ## CodeGrind Team

--- a/ui/embeds/notifications.py
+++ b/ui/embeds/notifications.py
@@ -47,8 +47,8 @@ def set_channels_instructions_embed(channel_id: int, adding: bool) -> discord.Em
     )
 
     embed.add_field(
-        name=f"Select which notification types the channel should "
-        f"{'start' if adding else 'stop'} receiving:",
+        name=f"Use the dropdown menu below to select which notification types the "
+        f"channel should {'start' if adding else 'stop'} receiving:",
         value="",
         inline=False,
     )

--- a/ui/views/notifications.py
+++ b/ui/views/notifications.py
@@ -5,6 +5,7 @@ from beanie.odm.operators.update.array import AddToSet, Pull
 
 from constants import NotificationOptions
 from database.models import Server
+from ui.embeds.common import failure_embed
 from ui.embeds.notifications import (
     channel_receiving_all_notification_options_embed,
     channel_receiving_no_notification_options_embed,
@@ -111,8 +112,13 @@ class SaveButton(discord.ui.Button):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         if not self.selected_notification_options:
+            embed = failure_embed(
+                title="No notification types selected",
+                description=f"Use the dropdown menu to select the notification types "
+                f"to {'enable' if self.adding else 'disable'}",
+            )
+            await interaction.response.send_message(embed=embed, ephemeral=True)
             return
-            # ! return error embed
 
         await self._save_channel_options(
             self.server_id,

--- a/ui/views/notifications.py
+++ b/ui/views/notifications.py
@@ -23,6 +23,7 @@ class NotificationOptionSelect(discord.ui.Select):
         self,
         selected_notification_options: set[NotificationOptions],
         available_notification_options: set[NotificationOptions],
+        adding: bool,
     ):
 
         self.label_to_option = {
@@ -34,7 +35,8 @@ class NotificationOptionSelect(discord.ui.Select):
         options = self._get_options(available_notification_options)
 
         super().__init__(
-            placeholder="Select notification types",
+            placeholder=f"Select the notification types to "
+            f"{'enable' if adding else 'disable'}",
             max_values=len(options),
             min_values=1,
             options=options,
@@ -191,7 +193,7 @@ class ChannelsSelectView(discord.ui.View):
         available_notification_options: set[NotificationOptions],
         adding: bool,
         *,
-        timeout=180
+        timeout=180,
     ):
 
         super().__init__(timeout=timeout)
@@ -199,7 +201,9 @@ class ChannelsSelectView(discord.ui.View):
         self.selected_notification_options = set()
         self.add_item(
             NotificationOptionSelect(
-                self.selected_notification_options, available_notification_options
+                self.selected_notification_options,
+                available_notification_options,
+                adding,
             )
         )
         self.add_item(

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -19,11 +19,8 @@ if TYPE_CHECKING:
 
 
 @tasks.loop(
-    time=[
-        time(hour=hour, minute=minute, second=0, microsecond=0)
-        for hour in range(24)
-        for minute in [0, 30]
-    ]
+    time=[time(hour=hour, minute=minute) for hour in range(24) for minute in [0, 30]],
+    reconnect=False,
 )
 async def schedule_question_and_stats_update(bot: "DiscordBot") -> None:
     """

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -407,6 +407,8 @@ async def fetch_problems_solved_and_rank(
         response_data = await bot.post_data(
             URL, json=payload, headers=HEADERS, timeout=10
         )
+        if not response_data:
+            return
 
         # Add a small delay to avoid rate limits, using random to avoid patterns
         await asyncio.sleep(random())


### PR DESCRIPTION
## Changes
- Add missing `response_data` NoneType check.
- It seems that `ext.tasks` retry sometimes on some specific exceptions silently, therefore the `reconnect` param has been set to `False`
- Update `/notifications` related embed content to improve clarity.
- Add ephemeral failure message if no notification types were selected when user presses the `save` button in `/notifications'.