### PR TITLE
Handle `asyncio.TimeoutError` in `fetch_data` and `post_data`

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -52,7 +52,7 @@ class StatsCog(commands.Cog):
             Preference.user_id == user_id, Preference.server_id == interaction.guild.id
         )
 
-        if user.id != interaction.user.id and not preference.url:
+        if not preference or (user.id != interaction.user.id and not preference.url):
             await interaction.followup.send(embed=account_hidden_embed())
             return
 

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -31,7 +31,7 @@ class HttpClient:
         try:
             async with self.session.get(*args, **kwargs) as response:
                 return await response.text()
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             self.bot.logger.exception(f"Failed to fetch data: {e}")
 
     @backoff.on_exception(backoff.expo, RateLimitExceededException, logger=None)
@@ -68,5 +68,5 @@ class HttpClient:
                                 f"Post request error: (code: {response.status})"
                             )
 
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 self.bot.logger.exception(f"Failed to post data: {e}")


### PR DESCRIPTION
## Changes
- Handle `asyncio.TimeoutError` which can occur in `discord.commands.ext.tasks` within `fetch_data` and `post_data` when `reconnect` is set to False. (https://stackoverflow.com/a/74110886)
- Check if selected `/stats` user has a preference to prevent preference from being `None`. This was an edge case which occurred if you use /stats on a user that has already connected their account to the bot but not to the server the command was ran from.