### PR TITLE
feat: fetch and include video solution link in `/neetcode` embed

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -34,6 +34,7 @@ from database.models import Preference, Server
 from database.setup import initialise_mongodb_conn
 from utils.dev import ChannelLogger
 from utils.http_client import HttpClient
+from utils.neetcode import NeetcodeSolutions, schedule_update_neetcode_solutions
 from utils.notifications import (
     process_daily_question_and_stats_update,
     schedule_question_and_stats_update,
@@ -73,6 +74,7 @@ class DiscordBot(commands.Bot):
         self.html2image = Html2Image(browser_executable=config.BROWSER_EXECUTABLE_PATH)
         self.channel_logger = ChannelLogger(self, self.config.LOGGING_CHANNEL_ID)
         self.ratings = Ratings(self)
+        self.neetcode = NeetcodeSolutions(self)
         self.http_client: HttpClient | None = None
         self.topggpy: topgg.DBLClient | None = None
 
@@ -138,6 +140,7 @@ class DiscordBot(commands.Bot):
         await self.init_topgg()
 
         schedule_update_ratings.start(self)
+        schedule_update_neetcode_solutions.start(self)
         schedule_question_and_stats_update.start(self)
 
     async def on_interaction(self, interaction: discord.Interaction) -> None:

--- a/ui/embeds/neetcode.py
+++ b/ui/embeds/neetcode.py
@@ -35,12 +35,15 @@ async def neetcode_embed(
     if not response_data:
         return error_embed()
 
-    embed = discord.Embed(
+    # `" " * 85` is needed to force the code block to span its max possible width.
+    code_block = f"```{language.value}\n{' ' * 85}\n{response_data}\n```"
+    if "||" not in code_block:
+        code_block = f"||{code_block}||"
+
+    return discord.Embed(
         title=f"{question_id}. {info.title} - NeetCode Solution "
         f"({language.value.capitalize()}) ",
         url="https://neetcode.io/",
-        # `" " * 85` is needed to force the code block to span its max possible width.
-        description=f"```{language.value}\n{' ' * 85}\n{response_data}\n```",
+        description=code_block,
         colour=discord.Colour.light_embed(),
     )
-    return embed

--- a/ui/embeds/neetcode.py
+++ b/ui/embeds/neetcode.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING
 import discord
 
 from constants import Language
-from ui.embeds.common import error_embed
+from ui.embeds.common import error_embed, failure_embed
 from ui.embeds.problems import question_error_embed
-from utils.neetcode import generate_neetcode_link
-from utils.problems import fetch_question_info, search_question
+from utils.neetcode import neetcode_solution_github_link
+from utils.problems import search_question
 
 if TYPE_CHECKING:
     # To prevent circular imports
@@ -17,33 +17,54 @@ async def search_neetcode_embed(
     bot: "DiscordBot", search_text: str, language: Language
 ) -> discord.Embed:
 
-    question_info = await search_question(bot, search_text)
-    if not question_info:
+    question_title = await search_question(bot, search_text)
+    if not question_title:
         return question_error_embed()
 
-    question_title, question_id = question_info
-    embed = await neetcode_embed(bot, question_id, question_title, language)
+    embed = await neetcode_embed(bot, question_title, language)
     return embed
 
 
 async def neetcode_embed(
-    bot: "DiscordBot", question_id: str, question_title: str, language: Language
+    bot: "DiscordBot", question_title: str, language: Language
 ) -> discord.Embed:
-    info = await fetch_question_info(bot, question_title)
-    neetcode_link = generate_neetcode_link(question_id, question_title, language)
-    response_data = await bot.http_client.fetch_data(neetcode_link, timeout=10)
+    if question_title not in bot.neetcode.solutions:
+        return failure_embed(title="No NeetCode solution exists for this problem")
+
+    info = bot.neetcode.solutions[question_title]
+    code_link = neetcode_solution_github_link(info.code, language)
+    response_data = await bot.http_client.fetch_data(code_link, timeout=10)
     if not response_data:
         return error_embed()
 
     # `" " * 85` is needed to force the code block to span its max possible width.
     code_block = f"```{language.value}\n{' ' * 85}\n{response_data}\n```"
     if "||" not in code_block:
-        code_block = f"||{code_block}||"
+        code_block = f"**Click to reveal the solution**:\n||{code_block}||"
 
-    return discord.Embed(
-        title=f"{question_id}. {info.title} - NeetCode Solution "
+    embed = discord.Embed(
+        title=f"{info.problem_id}. {info.name} - NeetCode Solution "
         f"({language.value.capitalize()}) ",
         url="https://neetcode.io/",
         description=code_block,
         colour=discord.Colour.light_embed(),
     )
+    embed.add_field(
+        name="Video solution", value=f"https://www.youtube.com/embed/{info.video}"
+    )
+    embed.add_field(name="Pattern", value=f"||{info.pattern}||")
+
+    compiled_groups = []
+    if info.blind75:
+        compiled_groups.append("Blind 75")
+    if info.neetcode150:
+        compiled_groups.append("NeetCode 150")
+
+    embed.set_footer(
+        text=(
+            "This problem is part of " + " and ".join(compiled_groups)
+            if compiled_groups
+            else ""
+        )
+    )
+    return embed

--- a/ui/embeds/problems.py
+++ b/ui/embeds/problems.py
@@ -27,7 +27,7 @@ async def daily_question_embed(bot: "DiscordBot") -> discord.Embed:
 
 
 async def search_question_embed(bot: "DiscordBot", search_text: str) -> discord.Embed:
-    question_title, _ = await search_question(bot, search_text)
+    question_title = await search_question(bot, search_text)
 
     if not question_title:
         return question_error_embed()

--- a/utils/neetcode.py
+++ b/utils/neetcode.py
@@ -1,13 +1,138 @@
+import json
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from discord.ext import tasks
+
 from constants import Language
 
+if TYPE_CHECKING:
+    # To prevent circular imports
+    from bot import DiscordBot
 
-def generate_neetcode_link(question_id: str, question_title: str, language: Language):
+
+@dataclass
+class NeetcodeSolution:
+    problem_id: int
+    title: str
+    name: str
+    pattern: str
+    difficulty: str
+    video: str
+    code: str
+    neetcode150: bool = False
+    blind75: bool = False
+
+
+class NeetcodeSolutions:
+    def __init__(self, bot: "DiscordBot") -> None:
+        self.bot = bot
+        # {link/question-title-slug: NeetcodeSolution}
+        self.solutions: dict[str, NeetcodeSolution] = {}
+
+    async def update_solutions(self) -> None:
+        """
+        Updates the solutions.
+        """
+        self.solutions = await self._fetch_neetcode_solutions()
+        self.bot.logger.info("Updated NeetCode solutions")
+
+    async def _fetch_neetcode_solutions(self) -> dict[int, NeetcodeSolution]:
+        """
+        Fetches the NeetCode solutions data.
+
+        :return: The dictionary mapping from link/question-title-slug to
+        `NeetcodeSolution`.
+        """
+        main_js_filename = await self._retrieve_neetcode_main_js_filename()
+
+        response_data = await self.bot.http_client.fetch_data(
+            f"https://neetcode.io/{main_js_filename}", timeout=10
+        )
+        if not response_data:
+            return
+
+        solutions = self._parse_main_js(response_data)
+        return solutions
+
+    async def _retrieve_neetcode_main_js_filename(self) -> str | None:
+        """
+        Fetches https://neetcode.io/ and retrieves the filename of the
+        main.[a-z0-9]{16}.js file.
+
+        :return: The full name of the main.[a-z0-9]{16}.js file.
+        """
+        response_data = await self.bot.http_client.fetch_data(
+            "https://neetcode.io/", timeout=10
+        )
+        if not response_data:
+            return
+
+        filename = re.search(r"main\.[a-z0-9]{16}\.js", response_data)
+        if not filename:
+            return
+
+        # Return the entire match.
+        return filename.group(0)
+
+    def _parse_main_js(self, main_js: str) -> dict[str, NeetcodeSolution]:
+        """
+        Parses the main.js file and finds the array of objects containing the solution
+        data.
+
+        :param main_js: The main_js file as a string.
+
+        :return: The dictionary mapping from link/question-title-slug to
+        `NeetcodeSolution`.
+        """
+        solutions_full = re.search(r"M=(\[\{.*?\}\])", main_js)
+        if not solutions_full:
+            return {}
+
+        solutions = solutions_full.group(1)
+        solutions = solutions.replace("!0", "true")
+        solutions = re.sub(r"([{,])(\w+):", r'\1"\2":', solutions)
+        solutions_objects: list[dict] = json.loads(solutions)
+
+        link_to_solution: dict[str, NeetcodeSolution] = {}
+        for solution in solutions_objects:
+            try:
+                title = solution["link"].strip("/")
+                link_to_solution[title] = NeetcodeSolution(
+                    problem_id=int(solution["code"].split("-")[0]),
+                    title=title,
+                    name=solution["problem"],
+                    pattern=solution["pattern"],
+                    difficulty=solution["difficulty"],
+                    video=solution["video"],
+                    code=solution["code"],
+                    neetcode150=True if "neetcode150" in solution else False,
+                    blind75=True if "blind75" in solution else False,
+                )
+            except ValueError as e:
+                self.bot.logger.exception(
+                    f"Error parsing a NeetCode solution ({solution}): {e}"
+                )
+
+        return link_to_solution
+
+
+@tasks.loop(hours=168)
+async def schedule_update_neetcode_solutions(bot: "DiscordBot") -> None:
+    # 168 hours = 1 week.
+    # NeetCode solutions data gets updated weekly.
+    await bot.neetcode.update_solutions()
+
+
+def neetcode_solution_github_link(github_code_filename: str, language: Language) -> str:
     """
-    Generates the NeetCode GitHub code url.
+    Generates the NeetCode GitHub solution code url.
 
-    :param question_id: The ID of the selected LeetCode problem.
-    :param question_title: The title of the selected LeetCode problem.
+    :param github_code_filename: The filename of the code solution.
     :param language: The selected programming language of the solution.
+
+    :return: The GitHub NeetCode solution link of the LC problem.
     """
     language_to_github = {
         Language.PYTHON3: {"name": "python", "extension": "py"},
@@ -26,13 +151,9 @@ def generate_neetcode_link(question_id: str, question_title: str, language: Lang
         Language.DART: {"name": "dart", "extension": "dart"},
     }
 
-    question_number = question_id.zfill(4)
-    neetcode_github_title = (
-        f"{question_number}-{question_title.replace(' ', '-').lower()}"
-    )
-    neetcode_link = (
+    link = (
         f"https://raw.githubusercontent.com/neetcode-gh/leetcode/main/"
-        f"{language_to_github[language]['name']}/{neetcode_github_title}."
+        f"{language_to_github[language]['name']}/{github_code_filename}."
         f"{language_to_github[language]['extension']}"
     )
-    return neetcode_link
+    return link

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -269,8 +269,7 @@ async def search_question(bot: "DiscordBot", text: str) -> str | None:
             ) {
                 questions:
                     data {
-                        titleSlug,
-                        questionFrontendId
+                        titleSlug
                     }
                 }
             }
@@ -295,7 +294,6 @@ async def search_question(bot: "DiscordBot", text: str) -> str | None:
             return
 
         question_title_slug = questions_matched_list["questions"][0]["titleSlug"]
-        question_id = questions_matched_list["questions"][0]["questionFrontendId"]
 
     except ValueError:
         bot.logger.exception(
@@ -303,7 +301,7 @@ async def search_question(bot: "DiscordBot", text: str) -> str | None:
         )
         return
 
-    return question_title_slug, question_id
+    return question_title_slug
 
 
 async def fetch_question_info(


### PR DESCRIPTION
## Description
The NeetCode solutions information is stored in a main.[random_letters_and_numbers].js file in neetcode.io, which can be seen in the sources tab in developer tools. However, the random mix of letters and numbers changes depending on the version of that file, so the solution I found is to fetch `https://neetcode.io`, read the script tag which mentions the most up-to-date version name of the file, then retrieve the file's data using `https://neetcode.io/main.[...].js`. Then the data within the file needs to be parsed using regex, converted to json.

## Changes
- Create `NeetcodeSolutions` class that stores the solutions and corresponding logic to fetch them from neetcode.io. The solutions are also updated weekly through the task decorator.
- Created a function to fetch the solutions, through the method explained in the description.
- Update the embed to display the video link, alongside pattern field, and footer containing information on which compiled group(s) the problem is in.
- Spoilered the code if no `||` found in the code block (because if there is one, it will mess with the formatting)

## Notes
There is no way to actually embed a youtube link within an embed, so for now the the URL link is just written in an embed field.