### PR TITLE
fix: spoiler tag collapses when code block contains || characters

### DIFF
--- a/ui/constants.py
+++ b/ui/constants.py
@@ -138,6 +138,7 @@ Note: please press the 'save' button twice!
 ### Developers
 Kevin (<@335154148976885770>)
 Nano (<@814656377188384810>)
+Liam (<@344132308644659201>)
 
 ### Contributors
 [Chris](<https://www.linkedin.com/in/chris-fowler-b3b96a191/>) (<@586527718653558796>): Created the /neetcode command.

--- a/ui/embeds/neetcode.py
+++ b/ui/embeds/neetcode.py
@@ -38,9 +38,13 @@ async def neetcode_embed(
         return error_embed()
 
     # `" " * 85` is needed to force the code block to span its max possible width.
-    code_block = f"```{language.value}\n{' ' * 85}\n{response_data}\n```"
-    if "||" not in code_block:
-        code_block = f"**Click to reveal the solution**:\n||{code_block}||"
+    code_block = f"**Click to reveal the solution**:\n||```{language}\n{" " * 85}\n"
+
+    if "||" in response_data:
+        response_data = response_data.replace("||", "|\u200b|")
+        # `U+200B` is a zero-width space character, this prevents Discord from collapsing the spoiler tag.
+
+    code_block += f"{response_data}```\n||"
 
     embed = discord.Embed(
         title=f"{info.problem_id}. {info.name} - NeetCode Solution "

--- a/ui/embeds/neetcode.py
+++ b/ui/embeds/neetcode.py
@@ -37,14 +37,16 @@ async def neetcode_embed(
     if not response_data:
         return error_embed()
 
-    # `" " * 85` is needed to force the code block to span its max possible width.
-    code_block = f"**Click to reveal the solution**:\n||```{language}\n{" " * 85}\n"
-
     if "||" in response_data:
+        # `U+200B` is a zero-width space character, this prevents Discord from
+        # collapsing the spoiler tag early.
         response_data = response_data.replace("||", "|\u200b|")
-        # `U+200B` is a zero-width space character, this prevents Discord from collapsing the spoiler tag.
 
-    code_block += f"{response_data}```\n||"
+    # `" " * 85` is needed to force the code block to span its max possible width.
+    code_block = (
+        f"**Click to reveal the solution**:\n||```{language}\n"
+        f"{' ' * 85}\n{response_data}```\n||"
+    )
 
     embed = discord.Embed(
         title=f"{info.problem_id}. {info.name} - NeetCode Solution "

--- a/ui/embeds/neetcode.py
+++ b/ui/embeds/neetcode.py
@@ -44,8 +44,8 @@ async def neetcode_embed(
 
     # `" " * 85` is needed to force the code block to span its max possible width.
     code_block = (
-        f"**Click to reveal the solution**:\n||```{language}\n"
-        f"{' ' * 85}\n{response_data}```\n||"
+        f"**Click to reveal the solution**:\n||```{language.value}\n{' ' * 85}"
+        f"\n{response_data}\n```||"
     )
 
     embed = discord.Embed(


### PR DESCRIPTION
## Description
Resolves an issue where the Discord spoiler tag would collapse if the code block contained `||` characters.

## Changes:
Check if `response_data` contains `||` characters, replace with `|\u200b|`

- `U+200B` is a zero-width space character. This prevents Discord from interpreting any `||` as the end of the spoiler tag.

## Note
The character will be present in the code if copied directly from the spoiler block. This may cause issues if the character is not accounted for before compiling. However, this trade-off is acceptable as users shouldn't be copying code directly without reviewing it first, and having consistent spoiler behaviour across questions is important to improve the user experience.