### PR TITLE
fix: prevent premium questions from being displayed with /problem random

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ lazy-model==0.2.0
 markdownify==0.12.1
 motor==3.4.0
 multidict==6.0.5
-pillow==10.2.0
+pillow==10.3.0
 proto-plus==1.23.0
 protobuf==4.25.3
 pyasn1==0.6.0

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -173,6 +173,7 @@ async def fetch_random_question(
         query randomQuestion($categorySlug: String, $filters: QuestionListFilterInput) {
             randomQuestion(categorySlug: $categorySlug, filters: $filters) {
                 titleSlug
+                isPaidOnly
             }
         }
         """,
@@ -193,6 +194,10 @@ async def fetch_random_question(
         return
 
     try:
+        # If the question is premium only, fetch a different question.
+        if response_data["data"]["randomQuestion"]["isPaidOnly"]:
+            return await fetch_random_question(bot, difficulty)
+
         title_slug = response_data["data"]["randomQuestion"]["titleSlug"]
 
     except ValueError:

--- a/utils/problems.py
+++ b/utils/problems.py
@@ -187,27 +187,36 @@ async def fetch_random_question(
         },
     }
 
-    response_data = await bot.http_client.post_data(
-        URL, json=payload, headers=HEADERS, timeout=10
-    )
-    if not response_data:
-        return
+    # Maximum number of attempts to fetch a non-premium question.
+    MAX_ATTEMPTS = 10
 
-    try:
-        # If the question is premium only, fetch a different question.
-        if response_data["data"]["randomQuestion"]["isPaidOnly"]:
-            return await fetch_random_question(bot, difficulty)
-
-        title_slug = response_data["data"]["randomQuestion"]["titleSlug"]
-
-    except ValueError:
-        bot.logger.exception(
-            f"fetch_random_question: failed to decode json. Error code "
-            f"({response_data})"
+    # Try to fetch a non-premium question for a maximum of MAX_ATTEMPTS times.
+    # This prevents excessive (and even possibly infinite) API calls, ensuring safety.
+    for _ in range(MAX_ATTEMPTS):
+        response_data = await bot.http_client.post_data(
+            URL, json=payload, headers=HEADERS, timeout=10
         )
-        return
+        if not response_data:
+            return
 
-    return title_slug
+        try:
+            question = response_data["data"]["randomQuestion"]
+
+            if not question["isPaidOnly"]:
+                return question["titleSlug"]
+
+        except ValueError:
+            bot.logger.exception(
+                f"fetch_random_question: failed to decode json. Error code "
+                f"({response_data})"
+            )
+            return
+
+    # Log a warning if no non-premium question is found after MAX_ATTEMPTS attempts.
+    bot.logger.warning(
+        f"fetch_random_question: failed to find an unpaid question after {MAX_ATTEMPTS} attempts"
+    )
+    return
 
 
 async def fetch_daily_question(bot: "DiscordBot") -> str | None:


### PR DESCRIPTION
Resolves issue [#153](https://github.com/CodeGrind-Team/CodeGrind-Bot/issues/153).

## Description
Improves the random problem retrieval process by excluding premium questions. This is achieved by adding the `isPaidOnly` field to the **fetch_random_question** GraphQL query. If the question is premium-only, we simply fetch another question.

## Changes
- Modified the GraphQL query in `./utils/problems.py - fetch_random_question` to include the `isPaidOnly` field.
- While `isPaidOnly` is True, we keep calling the **fetch_random_question** function until a non-premium question is found.

## Notes
This is _most likely_ the best solution. The LeetCode API only supports filtering to display premium questions, with no option to only display non-premium questions.

By including the `isPaidOnly` field within the **fetch_random_question** query, we check the premium status of a question without any extra API calls.

There are ~652 premium questions out of a possible 3199. Therefore, while there is ~20% chance to have to retry, it is much quicker (and provides a better user experience) to do this for them in the background instead of making them rerun the `/problem random` command (which would result in another request anyway).