### PR TITLE
fix: localize datetimes to display the correct timestamp

### DIFF
--- a/ui/embeds/leaderboards.py
+++ b/ui/embeds/leaderboards.py
@@ -1,5 +1,6 @@
 import discord
-
+from datetime import datetime, UTC
+import pytz
 from constants import DifficultyScore
 from database.models import Server
 from ui.embeds.common import failure_embed
@@ -24,11 +25,17 @@ def leaderboard_embed(
     embed = discord.Embed(
         title=title, description=leaderboard, colour=discord.Colour.yellow()
     )
+    # Converting the unaware datetime to a timezone-aware one is required
+    # to display the correct timestamp to the user.
 
     # Short Date/Time relative timestamp format: <t:{timestamp}:f>,
-    last_updated_start = f"<t:{int(server.last_update_start.timestamp())}:f>"
+    last_updated_start = (
+        f"<t:{int(pytz.utc.localize(server.last_update_start).timestamp())}:f>"
+    )
     # Short Time relative timestamp format: <t:{timestamp}:t>,
-    last_updated_end = f"<t:{int(server.last_update_end.timestamp())}:t>"
+    last_updated_end = (
+        f"<t:{int(pytz.utc.localize(server.last_update_end).timestamp())}:t>"
+    )
     page_count_text = (
         f"\n-# Page {page_i + 1}/{page_count}" if include_page_count else ""
     )
@@ -37,9 +44,9 @@ def leaderboard_embed(
     # still allowing the use of other markdown formatting and relative timestamps
     # unlike the embed's footer.
     embed.description += (
-        f"\n\n-# Easy: {DifficultyScore.EASY.value} point, Medium: "
-        f"{DifficultyScore.MEDIUM.value} points, Hard: {DifficultyScore.HARD.value} "
-        f"points"
+        f"\n\n-# Easy: {DifficultyScore.EASY.value} pt | Medium: "
+        f"{DifficultyScore.MEDIUM.value} pts | Hard: {DifficultyScore.HARD.value} "
+        f"pts"
         f"\n-# Updated on {last_updated_start} - {last_updated_end}"
         f"{page_count_text}"
     )


### PR DESCRIPTION
## The Issue
Datetimes displayed in the footer of leaderboard embeds were incorrect (1 hour in the past).

## What has been done
The issue was caused due to the unaware datetimes that were converted to timestamps. In order to display the correct timestamp, the datetimes had to be converted to timezone aware datetimes.

Also, the footer question difficulty helper text has been shortened to prevent wrapping on mobile devices.