### PR TITLE
feat: delete servers, users, and profiles when corresponding data is no longer needed

### DIFF
--- a/utils/neetcode.py
+++ b/utils/neetcode.py
@@ -3,8 +3,6 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from discord.ext import tasks
-
 from constants import Language
 
 if TYPE_CHECKING:
@@ -116,13 +114,6 @@ class NeetcodeSolutions:
                 )
 
         return link_to_solution
-
-
-@tasks.loop(hours=168)
-async def schedule_update_neetcode_solutions(bot: "DiscordBot") -> None:
-    # 168 hours = 1 week.
-    # NeetCode solutions data gets updated weekly.
-    await bot.neetcode.update_solutions()
 
 
 def neetcode_solution_github_link(github_code_filename: str, language: Language) -> str:

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -1,9 +1,8 @@
-from datetime import UTC, datetime, time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import discord
 from beanie.odm.operators.update.general import Set
-from discord.ext import tasks
 
 from constants import GLOBAL_LEADERBOARD_ID, Period
 from database.models import Server
@@ -15,17 +14,6 @@ from utils.stats import update_all_user_stats
 if TYPE_CHECKING:
     # To prevent circular imports
     from bot import DiscordBot
-
-
-@tasks.loop(
-    time=[time(hour=hour, minute=minute) for hour in range(24) for minute in [0, 30]],
-    reconnect=False,
-)
-async def schedule_question_and_stats_update(bot: "DiscordBot") -> None:
-    """
-    Schedule to send the daily question and update the stats.
-    """
-    await process_daily_question_and_stats_update(bot)
 
 
 async def process_daily_question_and_stats_update(

--- a/utils/ratings.py
+++ b/utils/ratings.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING
 
-from discord.ext import tasks
-
 if TYPE_CHECKING:
     # To prevent circular imports
     from bot import DiscordBot
@@ -38,10 +36,3 @@ class Ratings:
             ratings[title] = rating
 
         return ratings
-
-
-@tasks.loop(hours=168)
-async def schedule_update_ratings(bot: "DiscordBot") -> None:
-    # 168 hours = 1 week.
-    # Ratings get updated weekly.
-    await bot.ratings.update_ratings()

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,0 +1,56 @@
+from datetime import time
+from typing import TYPE_CHECKING
+
+from discord.ext import tasks
+
+from utils.dev import prune_members_and_guilds
+from utils.notifications import process_daily_question_and_stats_update
+
+if TYPE_CHECKING:
+    # To prevent circular imports
+    from bot import DiscordBot
+
+
+@tasks.loop(
+    time=[time(hour=hour, minute=minute) for hour in range(24) for minute in [0, 30]],
+    reconnect=False,
+)
+async def schedule_question_and_stats_update(bot: "DiscordBot") -> None:
+    """
+    Schedule to send the daily question and update the stats.
+    """
+    await process_daily_question_and_stats_update(bot)
+
+
+@tasks.loop(hours=168, reconnect=False)
+async def schedule_prune_members_and_guilds(bot: "DiscordBot") -> None:
+    """
+    Prune servers that don't have the bot in them, profiles of users that are not in
+    the corresponding guild anymore, and users that don't have any profiles.
+
+    168 hours == 1 week
+    """
+
+    # Skip the first loop as it is called immediately after starting the bot
+    if schedule_prune_members_and_guilds.current_loop == 0:
+        return
+
+    await prune_members_and_guilds(bot)
+
+
+@tasks.loop(hours=168)
+async def schedule_update_zerotrac_ratings(bot: "DiscordBot") -> None:
+    """
+    Update zerotrac ratings weekly.
+
+    168 hours == 1 week.
+    """
+    await bot.ratings.update_ratings()
+
+
+@tasks.loop(hours=24)
+async def schedule_update_neetcode_solutions(bot: "DiscordBot") -> None:
+    """
+    Update NeetCode solutions data daily.
+    """
+    await bot.neetcode.update_solutions()


### PR DESCRIPTION
## Issue
Even though servers, users, and profiles are deleted appropriately when for example users leave servers, or servers get deleted, this important task of deleting no longer needed information can be missed if the bot has an outage or downtime.

Therefore, determining which documents to delete and deleting them on a routinely basis (1 week), would be appropriate to fix this problem.

## What has been done
- Schedule a weekly task that prunes servers that don't have the bot in them, profiles of users that are not in the corresponding guild anymore, and users that don't have any profiles. Note that `fetch_guild` and `fetch_member` are used rather than their `get` counterpart, in order to get accurate and up-to-date data rather than using the cache.
- Move all schedules into a single file.
- Run Neetcode update solutions task daily rather than weekly. 