### PR TITLE
fix: delete global profile if user gets deleted during pruning and verify user is in `user_to_score[period]`

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -196,7 +196,7 @@ class DiscordBot(commands.Bot):
             Profile.server_id != GLOBAL_LEADERBOARD_ID,
         ).to_list()
 
-        if len(profiles) == 1 and profiles[0].server_id == GLOBAL_LEADERBOARD_ID:
+        if len(profiles) == 0:
             await delete_user(payload.user.id)
 
     async def on_member_update(

--- a/utils/leaderboards.py
+++ b/utils/leaderboards.py
@@ -109,7 +109,7 @@ async def user_and_score(
 
 async def all_users_and_scores(
     users: list[User], period: Period, previous: bool
-) -> list[User]:
+) -> list[tuple[User, int]]:
     """
     Fetch and calculate the scores for all users, for the selected time period.
 

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -159,7 +159,13 @@ async def update_wins(
             if not reset:
                 continue
 
-            max_score = max([user_to_score[period][user] for user in users])
+            max_score = max(
+                [
+                    user_to_score[period][user]
+                    for user in users
+                    if user in user_to_score[period]
+                ]
+            )
             # Scores of 0 don't count as a win.
             if max_score <= 0:
                 continue


### PR DESCRIPTION
## Issue
Due to the global profile of users not being deleted during pruning, this led to `user_to_score[period]` to not contain all the user ids, and as a user_id from a profile with no user was indexes, this led to a KeyError.

## What has been done
1. Verify that user is in `user_to_score[period]` before indexing.
2. Delete global profile if user is bound to get deleted during pruning. Alongside also deleting the user's records.