### PR TITLE
fix: handle event raised errors and add semaphore to concurrent user stats updates

### DIFF
--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     # To prevent circular imports
     from bot import DiscordBot
 
-semaphore = asyncio.Semaphore(4)
+http_post_semaphore = asyncio.Semaphore(4)
 
 
 class RateLimitExceededException(Exception):
@@ -48,7 +48,7 @@ class HttpClient:
 
         :return: The response JSON if the request is successful, otherwise None.
         """
-        async with semaphore:
+        async with http_post_semaphore:
             try:
                 async with self.session.post(*args, **kwargs) as response:
                     match response.status:


### PR DESCRIPTION
## The Issue(s)
1. Event raised errors calls the defined `on_error` static method (which is used as the tree's error handler), and thus leads to a parameter mismatch error.
2. Event raised errors aren't logged, and as these are generally critical errors, the bot doesn't currently gracefully close/restart it's system in this situation.
3. User stats updates are run concurrently however this can lead to all threads being blocked.

## The Solution
- Rename `on_error` static method to `tree_on_error`.
- Override `on_error` handler to log (with critical severity) the error, alongside gracefully closing the bot (this will restart it if in production).
- Wrap `update_stats` logic with a semaphore to prevent blocking all threads, and thus should allow users to run other commands whilst the stats routinely update.