### PR TITLE
fix: handle embed over length limit error

### DIFF
--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -112,8 +112,11 @@ async def send_daily_question(
 
         try:
             await channel.send(embed=embed, silent=True)
-        except discord.errors.Forbidden:
+        except (
+            discord.errors.Forbidden,
+            # Embed too large error.
+            discord.app_commands.errors.CommandInvokeError,
+        ):
             bot.logger.info(
-                f"Forbidden to share daily question to channel with ID: "
-                f"{channel_id}"
+                f"Exception sharing daily question to channel with ID: " f"{channel_id}"
             )


### PR DESCRIPTION
## The Issue
Accidental embeds over discord's limit leads to an error, that leads to the daily notifications not being sent.

## The solution
For the moment, just handle the error gracefully.