### PR TITLE
fix(utils/schedules): handle task exceptions and resume on next iteration

### DIFF
--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -67,7 +67,6 @@ class HttpClient:
                             self.bot.logger.exception(
                                 f"Post request forbidden access "
                                 f"(code: {response.status})",
-                                response.status,
                             )
                             self.bot.channel_logger.forbidden()
                         case _:

--- a/utils/roles.py
+++ b/utils/roles.py
@@ -21,7 +21,6 @@ def get_highest_tier_info(
         if val < tier_info.threshold:
             break
 
-        print(tier_info)
         highest_tier_info = tier_info
 
     return highest_tier_info

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,5 +1,6 @@
 from datetime import time
-from typing import TYPE_CHECKING
+from functools import wraps
+from typing import TYPE_CHECKING, Callable
 
 from discord.ext import tasks
 
@@ -11,10 +12,29 @@ if TYPE_CHECKING:
     from bot import DiscordBot
 
 
+def task_exception_handler(func: Callable) -> Callable:
+    """
+    Decorator to gracefully catch exceptions in a discord.ext.tasks.loop function and
+    allow it to continue running.
+
+    This allows the task to continue running on it's next scheduled iteration.
+    """
+
+    @wraps(func)
+    async def wrapper(bot: "DiscordBot", *args, **kwargs):
+        try:
+            await func(bot, *args, **kwargs)
+        except Exception as e:
+            bot.logger.critical(f"Task '{func.__name__}' encountered an error: {e}")
+
+    return wrapper
+
+
 @tasks.loop(
     time=[time(hour=hour, minute=minute) for hour in range(24) for minute in [0, 30]],
     reconnect=False,
 )
+@task_exception_handler
 async def schedule_question_and_stats_update(bot: "DiscordBot") -> None:
     """
     Schedule to send the daily question and update the stats.
@@ -23,6 +43,7 @@ async def schedule_question_and_stats_update(bot: "DiscordBot") -> None:
 
 
 @tasks.loop(hours=168, reconnect=False)
+@task_exception_handler
 async def schedule_prune_members_and_guilds(bot: "DiscordBot") -> None:
     """
     Prune servers that don't have the bot in them, profiles of users that are not in
@@ -39,6 +60,7 @@ async def schedule_prune_members_and_guilds(bot: "DiscordBot") -> None:
 
 
 @tasks.loop(hours=168)
+@task_exception_handler
 async def schedule_update_zerotrac_ratings(bot: "DiscordBot") -> None:
     """
     Update zerotrac ratings weekly.
@@ -49,6 +71,7 @@ async def schedule_update_zerotrac_ratings(bot: "DiscordBot") -> None:
 
 
 @tasks.loop(hours=24)
+@task_exception_handler
 async def schedule_update_neetcode_solutions(bot: "DiscordBot") -> None:
     """
     Update NeetCode solutions data daily.


### PR DESCRIPTION
## Issue description
- `response.status` is logged twice, the second time without f-string, potentially causing an exception in certain rare situations.
- Scheduled discord tasks sometimes lead to exceptions, and due to `reconnect` being set to False, once they fail they don't resume. This is intentional functionality, but we want to address this to gracefully handle the exceptions, log them, and resume the task in its next scheduled iteration.

## Solution implemented
- Remove the remnant print statement in `utils/roles`.
- Remove the repeated `response.status` log.
- Create and wrap all tasks with a task exception handler.

## Testing carried out
- [x] Tested on CodeGrind Bot Alpha and works as intended