### PR TITLE
fix(utils/problems): replace regex with HTML parsing, and limit embed size

### DIFF
--- a/src/cogs/problems.py
+++ b/src/cogs/problems.py
@@ -49,9 +49,9 @@ class ProblemsCog(commands.GroupCog, name="problem"):
         try:
             await interaction.followup.send(embed=embed)
         except discord.errors.HTTPException:
-            self.bot.logger.info(
+            self.bot.logger.exception(
                 "HTTPException raised when trying to share daily questions to channel "
-                "with ID: {interaction.channel_id}. Embed length over limit."
+                f"with ID: {interaction.channel_id}. Embed length over limit."
             )
 
     @app_commands.command(name="random")


### PR DESCRIPTION
## Description
To solve https://github.com/CodeGrind-Team/CodeGrind-Bot/issues/181, the regex used to replace tags has been replaced with a custom Markdown Converter. Additionally, to prevent the embed's description and field limit from being exceeded, the final content is sliced to fit the limit.

The solution still isn't very robust, but should perform better than before, as seen in testing.