### PR TITLE
chore(utils/stats): replace `html2image` with `playwright`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.12.13
-aiosignal==1.3.2
+aiohttp==3.12.14
+aiosignal==1.4.0
 annotated-types==0.7.0
 attrs==25.3.0
 backoff==2.2.1
@@ -23,10 +23,10 @@ google-cloud-audit-log==0.3.2
 google-cloud-core==2.4.3
 google-cloud-logging==3.12.1
 googleapis-common-protos==1.70.0
+greenlet==3.2.3
 grpc-google-iam-v1==0.14.2
 grpcio==1.73.0
 grpcio-status==1.73.0
-html2image==2.0.7
 idna==3.10
 importlib_metadata==8.7.0
 lazy-model==0.2.0
@@ -35,6 +35,7 @@ motor==3.7.1
 multidict==6.4.4
 opentelemetry-api==1.34.1
 pillow==11.3.0
+playwright==1.53.0
 propcache==0.3.2
 proto-plus==1.26.1
 protobuf==6.31.1
@@ -42,6 +43,7 @@ pyasn1==0.6.1
 pyasn1_modules==0.4.2
 pydantic==2.11.7
 pydantic_core==2.33.2
+pyee==13.0.0
 pymongo==4.13.2
 python-dotenv==1.1.1
 pytz==2025.2

--- a/src/cogs/stats.py
+++ b/src/cogs/stats.py
@@ -23,7 +23,7 @@ class StatsCog(commands.Cog):
         Activity = StatsCardExtensions.ACTIVITY
         Heatmap = StatsCardExtensions.HEATMAP
         Contest = StatsCardExtensions.CONTEST
-        Default = StatsCardExtensions.NONE
+        Stats_Only = StatsCardExtensions.NONE
 
     def __init__(self, bot: "DiscordBot") -> None:
         self.bot = bot

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,6 @@ if __name__ == "__main__":
     config = Config(
         environ["DISCORD_TOKEN"],
         environ["MONGODB_URI"],
-        environ["BROWSER_EXECUTABLE_PATH"],
         int(environ["LOGGING_CHANNEL_ID"]),
         int(environ["DEVELOPER_DISCORD_ID"]),
         os.getenv("PRODUCTION", "False") == "True",

--- a/src/ui/embeds/stats.py
+++ b/src/ui/embeds/stats.py
@@ -1,5 +1,3 @@
-import random
-import string
 from typing import TYPE_CHECKING
 
 import discord
@@ -20,13 +18,12 @@ async def stats_embed(
     display_url: bool,
     extension: StatsCardExtensions,
 ) -> tuple[discord.Embed, discord.File | None]:
-    # Use a randomised filename for privacy.
-    filename = "".join(random.choices(string.ascii_letters + string.digits, k=25))
+    file_created = await stats_card(bot, leetcode_id, extension, display_url)
 
-    file = await stats_card(bot, leetcode_id, filename, extension, display_url)
-
-    if not file:
+    if not file_created:
         return error_embed(), None
+
+    filename, file = file_created
 
     embed = discord.Embed(
         title=display_name,

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -11,6 +11,7 @@ from src.constants import DifficultyScore
 def to_thread(func: Callable) -> Callable:
     """
     Decorator to run a function in a separate thread.
+    Useful for blocking operations that should not block the event loop.
 
     :param func: The function to run in a separate thread.
 

--- a/src/utils/problems.py
+++ b/src/utils/problems.py
@@ -507,7 +507,7 @@ async def fetch_problems_solved_and_rank(
         matched_user = response_data["data"]["matchedUser"]
 
         if not matched_user:
-            return None
+            return
 
         real_name = matched_user["profile"]["realName"]
         submit_stats_global = matched_user["submitStatsGlobal"]


### PR DESCRIPTION
## Description

`html2image` depends on a Chromium-based browser, and due to older/archived Chromium arm64 versions not being available, it is not possible to continue using `html2image`.

The reason we need to use an older version of Chromium is that the new headless mode currently contains supposed bugs that lead to issues when taking screenshots.

`Playwright` was chosen as it can install and setup its own Chromium instance in headless mode, which seems not to have the issues mentioned previously.