### PR TITLE
chore(docker): add Docker containerisation support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,94 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/
+
+# CodeGrind specific
+src/temp
+src/logs
+**/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY src/ /app/src/
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
+    python -m playwright install-deps && \
+    python -m playwright install
+
+CMD ["python", "-m", "src.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: codegrind-bot
+    env_file:
+      - .env
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /app/google_cloud_service_key.json
+    volumes:
+      - ./google_cloud_service_key.json:/app/google_cloud_service_key.json:ro
+    restart: unless-stopped
+
+  datadog:
+    image: gcr.io/datadoghq/agent:latest
+    container_name: datadog-agent
+    env_file:
+      - .env
+    environment:
+      - DD_API_KEY=${DD_API_KEY:-}
+      - DD_SITE=us5.datadoghq.com
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_PROCESS_AGENT_ENABLED=true
+    ports:
+      - "8125:8125/udp"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+    restart: unless-stopped
+    profiles: [ "datadog" ]

--- a/src/bot.py
+++ b/src/bot.py
@@ -29,6 +29,7 @@ import aiohttp
 import discord
 import topgg
 from beanie.odm.operators.update.general import Set
+from datadog.dogstatsd.base import statsd
 from discord.ext import commands
 from playwright.async_api import Browser, Playwright, async_playwright
 
@@ -207,6 +208,10 @@ class DiscordBot(commands.Bot):
                 f"Executed /{executed_command} command by {interaction.user.name} "
                 f"(ID: {interaction.user.id}) in DMs"
             )
+
+        statsd.increment(
+            "discord.command.executed", tags=["command:" + executed_command]
+        )
 
     async def on_guild_remove(self, guild: discord.Guild) -> None:
         """

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,8 @@ from src.observability.monitoring import setup_datadog
 if __name__ == "__main__":
     load_dotenv(find_dotenv())
 
+    google_application_credentials = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+
     config = Config(
         environ["DISCORD_TOKEN"],
         environ["MONGODB_URI"],
@@ -19,7 +21,12 @@ if __name__ == "__main__":
         int(environ["DEVELOPER_DISCORD_ID"]),
         os.getenv("PRODUCTION", "False") == "True",
         os.getenv("TOPGG_TOKEN"),
-        os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+        (
+            google_application_credentials
+            if google_application_credentials is not None
+            and os.path.isfile(google_application_credentials)
+            else None
+        ),
         os.getenv("DD_API_KEY"),
         os.getenv("DD_APP_KEY"),
     )

--- a/src/observability/monitoring/datadog_client.py
+++ b/src/observability/monitoring/datadog_client.py
@@ -2,6 +2,14 @@ from datadog import initialize
 
 from src.bot import Config
 
+DD_STATSD_HOST = "datadog"
+DD_STATSD_PORT = 8125
+
 
 def setup_datadog(config: Config) -> None:
-    initialize(api_key=config.DD_API_KEY, app_key=config.DD_APP_KEY)
+    initialize(
+        api_key=config.DD_API_KEY,
+        app_key=config.DD_APP_KEY,
+        statsd_host=DD_STATSD_HOST,
+        statsd_port=DD_STATSD_PORT,
+    )


### PR DESCRIPTION
## Description
With the completion of #219, a `Dockerfile` and `docker-compose.yml` can be created to setup CodeGrind-Bot and all its dependencies, both on arm64 and amd64.

Added Docker containerisation support for CodeGrind-Bot, enabling deployment in containers with proper dependency management and monitoring integration.
- Implemented Docker containerisation with Dockerfile and docker-compose configuration.
- Integrated Datadog agent for statsd metric collection.