### PR TITLE
chore(requirements): upgrade `beanie` to `2.0.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiosignal==1.4.0
 annotated-types==0.7.0
 attrs==25.3.0
 backoff==2.2.1
-beanie==1.30.0
+beanie==2.0.0
 beautifulsoup4==4.13.4
 cachetools==5.5.2
 certifi==2025.6.15
@@ -29,7 +29,7 @@ grpcio==1.73.0
 grpcio-status==1.73.0
 idna==3.10
 importlib_metadata==8.7.0
-lazy-model==0.2.0
+lazy-model==0.3.0
 markdownify==1.1.0
 motor==3.7.1
 multidict==6.4.4


### PR DESCRIPTION
This release moves away from [Motor](https://motor.readthedocs.io/en/stable/) in favor of the [PyMongo Async API](https://pymongo.readthedocs.io/en/latest/api/pymongo/asynchronous/index.html).