### PR TITLE
fix(main): setup Datadog conditionally based on production environment

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,9 @@ if __name__ == "__main__":
     discord_bot_logger.setLevel(logging.INFO)
 
     add_logging_handlers(config)
-    setup_datadog(config)
+
+    if config.PRODUCTION:
+        setup_datadog(config)
 
     try:
         bot = DiscordBot(intents, config, discord_bot_logger)


### PR DESCRIPTION
## Datadog

Setting up Datadog in Python when Datadog API/APP keys are provided, but the Datadog agent isn't running, leads to errors in the attempts to send statsd metrics.

To address this, we now make sure that `setup_datadog` is only run when in production. 