### PR TITLE
chore(dockerfile): move `src` COPY after dependencies and disable datadog logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 FROM python:3.13-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
-COPY src/ /app/src/
 COPY requirements.txt /app/requirements.txt
 
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
     python -m playwright install-deps && \
     python -m playwright install
+
+# Copy the source code after installing dependencies such that changes in
+# the source code do not invalidate the Docker cache for dependencies.
+COPY src/ /app/src/
 
 CMD ["python", "-m", "src.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - DD_SITE=us5.datadoghq.com
       - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
       - DD_PROCESS_AGENT_ENABLED=true
-      - DD_LOGS_ENABLED=true
+      - DD_LOGS_ENABLED=false # Temporarily disabled.
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_CONTAINER_EXCLUDE=name:datadog-agent
       - DD_HOSTNAME_TRUST_UTS_NAMESPACE=true

--- a/src/observability/logging/logging_handlers.py
+++ b/src/observability/logging/logging_handlers.py
@@ -1,8 +1,16 @@
 from src.bot import Config
 
-from .handlers import add_console_handler, add_file_handler, add_json_handler
+from .handlers import (
+    add_console_handler,
+    add_file_handler,
+    add_gcp_handler,
+)
 
-PRODUCTION_HANDLERS = [add_json_handler]
+PRODUCTION_HANDLERS = [
+    # Re-add once fixed: add_json_handler
+    add_console_handler,
+    add_gcp_handler,
+]
 NON_PRODUCTION_HANDLERS = [
     add_console_handler,
     add_file_handler,


### PR DESCRIPTION
## Description

Copy the source code after installing dependencies such that changes in the source code do not invalidate the Docker cache for dependencies.

Additionally, temporarily disable Datadog logging due to issues that will need to be looked into.