### PR TITLE
chore(utils): create StatsD metrics for role updates and pruning

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -189,7 +189,7 @@ class DiscordBot(commands.Bot):
         statsd.service_check(
             "discord.bot.status",
             DogStatsd.OK,
-            tags=["bot:" + self.user.name if self.user else "Unknown"],
+            tags=[f"bot:{self.user.name if self.user else 'Unknown'}"],
         )
 
     async def on_interaction(self, interaction: discord.Interaction) -> None:
@@ -217,12 +217,12 @@ class DiscordBot(commands.Bot):
 
         statsd.increment(
             "discord.commands.count",
-            tags=["command:" + executed_command],
+            tags=[f"command:{executed_command}"],
         )
         statsd.timing(
             "discord.commands.duration",
             (datetime.now(UTC) - interaction.created_at).total_seconds(),
-            tags=["command:" + executed_command],
+            tags=[f"command:{executed_command}"],
         )
 
     async def on_guild_remove(self, guild: discord.Guild) -> None:
@@ -309,19 +309,6 @@ class DiscordBot(commands.Bot):
 
         await dev_commands(self, message)
 
-    async def on_disconnect(self) -> None:
-        """
-        Called when the client has disconnected from Discord, or a connection attempt
-        to Discord has failed. This could happen either through the internet being
-        disconnected, explicit calls to close, or Discord terminating the connection
-        one way or the other.
-        """
-        statsd.service_check(
-            "discord.bot.status",
-            DogStatsd.WARNING,
-            tags=["bot:" + self.user.name if self.user else "Unknown"],
-        )
-
     async def close(self) -> None:
         """
         Closes the connection to Discord, gracefully closes the session, and reboots
@@ -335,7 +322,7 @@ class DiscordBot(commands.Bot):
         statsd.service_check(
             "discord.bot.status",
             DogStatsd.CRITICAL,
-            tags=["bot:" + self.user.name if self.user else "Unknown"],
+            tags=[f"bot:{self.user.name if self.user else 'Unknown'}"],
         )
 
         try:

--- a/src/utils/leaderboards.py
+++ b/src/utils/leaderboards.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import discord
 from beanie.operators import In
+from datadog.dogstatsd.base import statsd
 
 from src.constants import GLOBAL_LEADERBOARD_ID, LeaderboardSortBy, Period, RankEmoji
 from src.database.models import Profile, Record, Server, User
@@ -488,3 +489,7 @@ async def send_leaderboard_winners(
                 f"Missing permissions on channel ({channel_id}) to send leaderboard "
                 "winners."
             )
+
+        statsd.increment(
+            "discord.bot.notifications.sent", tags=["type:leaderboard_winners"]
+        )

--- a/src/utils/notifications.py
+++ b/src/utils/notifications.py
@@ -133,3 +133,5 @@ async def send_daily_question(
             bot.logger.info(
                 f"Forbidden to share daily question to channel with ID: {channel_id}"
             )
+
+        statsd.increment("discord.bot.notifications.sent", tags=["type:daily_question"])

--- a/src/utils/roles.py
+++ b/src/utils/roles.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import discord
+from datadog.dogstatsd.base import statsd
 from discord import Role
 
 from src.constants import (
@@ -170,6 +171,7 @@ async def give_verified_role(guild: discord.Guild, member: discord.Member) -> No
         return
 
     await member.add_roles(role)
+    statsd.increment("discord.bot.roles.added")
 
 
 async def give_tier_group_role(
@@ -197,7 +199,9 @@ async def give_tier_group_role(
         role = discord.utils.get(guild.roles, name=codegrind_tier.role_name)
         if role and role in member.roles and role != role_to_assign:
             await member.remove_roles(role)
+            statsd.increment("discord.bot.roles.removed")
 
     if role_to_assign:
         # Give the member the appropriate role.
         await member.add_roles(role_to_assign)
+        statsd.increment("discord.bot.roles.added")

--- a/src/utils/schedules.py
+++ b/src/utils/schedules.py
@@ -71,7 +71,7 @@ async def schedule_prune_members_and_guilds(bot: "DiscordBot") -> None:
     await prune_members_and_guilds(bot)
 
 
-@tasks.loop(hours=168)
+@tasks.loop(hours=168, reconnect=False)
 @task_exception_handler
 async def schedule_update_zerotrac_ratings(bot: "DiscordBot") -> None:
     """
@@ -82,7 +82,7 @@ async def schedule_update_zerotrac_ratings(bot: "DiscordBot") -> None:
     await bot.ratings.update_ratings()
 
 
-@tasks.loop(hours=24)
+@tasks.loop(hours=24, reconnect=False)
 @task_exception_handler
 async def schedule_update_neetcode_solutions(bot: "DiscordBot") -> None:
     """


### PR DESCRIPTION
## Description

Add StatsD metrics for the pruning task and role feature related data.

- Added StatsD metrics for tracking role updates, server counts, and notification events.
- Implemented database pruning metrics to monitor data cleanup operations.
- Updated StatsD tag formatting for consistency and removed confusing `on_disconnect` service check.
- Made sure to remove profiles during pruning when the server no longer exists.