### PR TITLE
chore(bot): use `AutoShardedBot` for automatic sharding

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -64,7 +64,7 @@ class Config:
     DD_APP_KEY: str | None
 
 
-class DiscordBot(commands.Bot):
+class DiscordBot(commands.AutoShardedBot):
     def __init__(
         self, intents: discord.Intents, config: Config, logger: logging.Logger
     ) -> None:


### PR DESCRIPTION
## Description

Use automatic sharding by changing the base class from `commands.Bot` to `commands.AutoShardedBot`. This change enables the bot to automatically handle sharding as it scales across multiple Discord guilds, which is required by Discord once we reach 2.5k guilds.