### PR TITLE
chore(observability/logging): enable JSON logging for Datadog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - DD_SITE=us5.datadoghq.com
       - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
       - DD_PROCESS_AGENT_ENABLED=true
-      - DD_LOGS_ENABLED=false # Temporarily disabled.
+      - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_CONTAINER_EXCLUDE=name:datadog-agent
       - DD_HOSTNAME_TRUST_UTS_NAMESPACE=true

--- a/src/observability/logging/handlers/json_logger.py
+++ b/src/observability/logging/handlers/json_logger.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import json_log_formatter
 
@@ -7,7 +6,7 @@ from src.bot import Config
 
 
 def add_json_handler(config: Config) -> None:
-    formatter = json_log_formatter.JSONFormatter()
-    json_handler = logging.StreamHandler(sys.stdout)
+    formatter = json_log_formatter.VerboseJSONFormatter()
+    json_handler = logging.StreamHandler()
     json_handler.setFormatter(formatter)
     logging.getLogger().addHandler(json_handler)

--- a/src/observability/logging/logging_handlers.py
+++ b/src/observability/logging/logging_handlers.py
@@ -3,18 +3,15 @@ from src.bot import Config
 from .handlers import (
     add_console_handler,
     add_file_handler,
-    add_gcp_handler,
+    add_json_handler,
 )
 
 PRODUCTION_HANDLERS = [
-    # Re-add once fixed: add_json_handler
-    add_console_handler,
-    add_gcp_handler,
+    add_json_handler,
 ]
 NON_PRODUCTION_HANDLERS = [
     add_console_handler,
     add_file_handler,
-    # add_gcp_handler
 ]
 
 


### PR DESCRIPTION
## Description
Enable JSON logging for Datadog integration by replacing the GCP handler with a verbose JSON formatter and enabling log collection in the Datadog agent configuration.

- Switched from `JSONFormatter` to `VerboseJSONFormatter` to provide structured logging with `message` and `levelname` fields. The `levelname` attribute needed to be remapped as the `status` attribute within Datadog.
- Replaced GCP logging handler with JSON handler in the production environment.
- Enabled Datadog log collection in Docker Compose configuration.