### PR TITLE
chore(bot): change `on_disconnect` service check status to WARNING

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -198,7 +198,7 @@ class DiscordBot(commands.AutoShardedBot):
         self.logger.info("Bot is disconnected.")
         statsd.service_check(
             "discord.bot.status",
-            DogStatsd.CRITICAL,
+            DogStatsd.WARNING,
         )
 
     async def on_interaction(self, interaction: discord.Interaction) -> None:

--- a/src/utils/schedules.py
+++ b/src/utils/schedules.py
@@ -91,7 +91,7 @@ async def schedule_update_neetcode_solutions(bot: "DiscordBot") -> None:
     await bot.neetcode.update_solutions()
 
 
-@tasks.loop(minutes=1, reconnect=False)
+@tasks.loop(seconds=30, reconnect=False)
 @task_exception_handler
 async def schedule_ok_service_check(bot: "DiscordBot") -> None:
     """


### PR DESCRIPTION
## Description
- Changed the service check status sent on bot disconnect from `CRITICAL` to `WARNING` in `src/bot.py`, making the alert less severe when the bot randomly disconnects.
- Increased the frequency of the OK service check task in `utils/schedules.py` from every 1 minute to every 30 seconds, allowing for quicker detection of issues.